### PR TITLE
Change signature of search_with_options and match_with_options methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "onig"
 version = "0.3.4"
-authors = ["Will Speak <will@willspeak.me>"]
+authors = ["Will Speak <will@willspeak.me>", "Ivan Ivashchenko <defuz@me.com>"]
 
 description = """Rust-Onig is a set of rust bindings for the
             oniguruma regular expression library."""

--- a/examples/simple_grep.rs
+++ b/examples/simple_grep.rs
@@ -24,7 +24,10 @@ fn main() {
     for line in stdin.lock().lines() {
         if let Ok(line) = line {
             for (name, regex) in regexes.iter() {
-                let res = regex.search_with_options(&line, onig::SEARCH_OPTION_NONE, None);
+                let res = regex.search_with_options(&line,
+                                                    0, line.len(),
+                                                    onig::SEARCH_OPTION_NONE,
+                                                    None);
                 match res {
                     Some(pos) => println!("{} => matched @ {}", name, pos),
                     None => println!("{} => did not match", name)

--- a/src/captures.rs
+++ b/src/captures.rs
@@ -7,7 +7,8 @@ impl Regex {
     /// If no match is found, then `None` is returned.
     pub fn captures<'t>(&self, text: &'t str) -> Option<Captures<'t>> {
         let mut region = Region::new();
-        self.search_with_options(text, SEARCH_OPTION_NONE, Some(&mut region))
+        self.search_with_options(text, 0, text.len(),
+                                 SEARCH_OPTION_NONE, Some(&mut region))
             .map(|_| Captures {
                 text: text,
                 region: region,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -74,7 +74,7 @@ mod tests {
                                         REGEX_OPTION_NONE,
                                         &syntax).unwrap();
 
-        let r = regex.search_with_options("- cd aaabbb -",
+        let r = regex.search_with_options("- cd aaabbb -", 0, 13,
                                           SEARCH_OPTION_NONE,
                                           Some(&mut region));
 


### PR DESCRIPTION
I added new arguments to methods `search_with_options` and `match_with_options`:

- `at` for `match_with_options`
- `from` and `to` for `search_with_options`

Rationale:

- Sometimes it is necessary to search inside subrange of passed string and get the **absolute** indices of the matches. For example, if you want to find **all** matches of some pattern in a string, you should be able to start search from some position, but get matching indices from the start of base string.
- It makes possible to perform backward search.