### PR TITLE
Fix classification of ONIG_OPTION_CAPTURE_GROUP

### DIFF
--- a/src/flags.rs
+++ b/src/flags.rs
@@ -28,7 +28,13 @@ bitflags! {
         /// `SYNTAX_POSIX_BASIC`, `SYNTAX_POSIX_EXTENDED`,
         /// `SYNTAX_PERL`, `SYNTAX_PERL_NG`, `SYNTAX_JAVA`.
         const REGEX_OPTION_NEGATE_SINGLELINE
-            = onig_sys::ONIG_OPTION_NEGATE_SINGLELINE
+            = onig_sys::ONIG_OPTION_NEGATE_SINGLELINE,
+        /// Only named group captured.
+        const REGEX_OPTION_DONT_CAPTURE_GROUP
+            = onig_sys::ONIG_OPTION_DONT_CAPTURE_GROUP,
+        /// Named and no-named group captured.
+        const REGEX_OPTION_CAPTURE_GROUP
+            = onig_sys::ONIG_OPTION_CAPTURE_GROUP,
     }
 }
 
@@ -38,12 +44,6 @@ bitflags! {
         /// Default options.
         const SEARCH_OPTION_NONE
             = onig_sys::ONIG_OPTION_NONE,
-        /// Only named group captured.
-        const SEARCH_OPTION_DONT_CAPTURE_GROUP
-            = onig_sys::ONIG_OPTION_DONT_CAPTURE_GROUP,
-        /// Named and no-named group captured.
-        const SEARCH_OPTION_CAPTURE_GROUP
-            = onig_sys::ONIG_OPTION_CAPTURE_GROUP,
         /// String head isn't considered as begin of line.
         const SEARCH_OPTION_NOTBOL
             = onig_sys::ONIG_OPTION_NOTBOL,


### PR DESCRIPTION
`ONIG_OPTION_CAPTURE_GROUP` and `ONIG_OPTION_DONT_CAPTURE_GROUP` are actually flags for onig_new and hence should be regex options and not search options. Previously it was impossible to enable named captures and if you used those search flags it probably activated some other option, or did nothing. See: https://github.com/kkos/oniguruma/blob/master/doc/API

I discovered this because I currently have no way to get regexes involving named captures to compile.

If you want me to maintain the `SEARCH_OPTION_CAPTURE_GROUP` and its negation for backwards compatibility I can do that. But I think removing them will be fine since they don't do anything, if you were to try and use them for their intended purpose you would run into this bug compiling your regexes, and no code on Github or anywhere else on the internet uses them. I think you could even classify this as a bugfix in semver.

@defuz @iwillspeak 