### PR TITLE
Add Clone impl for Region

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,6 +400,11 @@ mod tests {
         let pos2 = region.pos(1).unwrap();
         assert_eq!(pos1, (1, 4));
         assert_eq!(pos2, (2, 4));
+
+        // test cloning here since we already have a filled region
+        let cloned_region = region.clone();
+        let pos1_clone = cloned_region.pos(0).unwrap();
+        assert_eq!(pos1_clone, pos1);
     }
 
     #[test]

--- a/src/region.rs
+++ b/src/region.rs
@@ -112,6 +112,16 @@ impl Drop for Region {
     }
 }
 
+impl Clone for Region {
+    fn clone(&self) -> Self {
+        let mut new_region = Region::new();
+        unsafe {
+            onig_sys::onig_region_copy(&mut new_region.raw, &self.raw);
+        }
+        new_region
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -125,6 +135,13 @@ mod tests {
     fn test_region_clear() {
         let mut region = Region::new();
         region.clear();
+    }
+
+    #[test]
+    fn test_region_copy() {
+        let region = Region::new();
+        let new_region = region.clone();
+        assert_eq!(new_region.len(), region.len());
     }
 
     #[test]


### PR DESCRIPTION
Implements Clone for region using the existing `onig_region_copy` function from `onig_sys`. I need this for my [syntect](https://github.com/trishume/syntect) project so that I can allow users to clone parser states so that they can cache them and not re-highlight entire files when one character changes.

@iwillspeak @defuz 