### PR TITLE
Pattern Implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,11 @@ rust:
 - beta
 - nightly
 
+env:
+  - ONIG_FEATURES=
+
 script:
-- cargo build --verbose
+- cargo build --features="$ONIG_FEATURES" --verbose
 - |
   if [ "$TRAVIS_OS_NAME" == "linux" ]
   then
@@ -18,8 +21,8 @@ script:
     echo "adding $p to linker path"
     export LD_LIBRARY_PATH="${p}:${LD_LIBRARY_PATH}"
   fi
-- cargo test --verbose
-- cargo doc --verbose
+- cargo test --features="$ONIG_FEATURES" --verbose
+- cargo doc --features="$ONIG_FEATURES" --verbose
 
 # Build the docs if we have had a successful master build
 after_success:
@@ -39,3 +42,7 @@ after_success:
 matrix:
   allow_failures:
     - rust: nightly
+  include:
+    - rust: nightly
+      env: ONIG_FEATURES=std-pattern
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,5 +44,9 @@ matrix:
     - rust: nightly
   include:
     - rust: nightly
+      os: linux
+      env: ONIG_FEATURES=std-pattern
+    - rust: nightly
+      os: osx
       env: ONIG_FEATURES=std-pattern
     

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ documentation = "http://rust-onig.github.io/rust-onig/onig/"
 readme = "README.md"
 license = "MIT"
 
+[features]
+std-pattern = []
+
 [dependencies]
 libc = "0.2"
 bitflags = "0.4"

--- a/src/find.rs
+++ b/src/find.rs
@@ -273,6 +273,7 @@ impl<'r, 't> Iterator for FindMatches<'r, 't> {
             return None;
         }
         let (s, e) = self.region.pos(0).unwrap();
+        self.last_end = e;
 
         // Don't accept empty matches immediately following a match.
         // i.e., no infinite loops please.
@@ -284,9 +285,9 @@ impl<'r, 't> Iterator for FindMatches<'r, 't> {
                 return self.next();
             }
         } else {
-            self.last_end = e;
             self.skip_next_empty = true;
         }
+
         Some((s, e))
     }
 }
@@ -471,6 +472,13 @@ mod tests {
         let re = Regex::new(r"\d*").unwrap();
         let ms = re.find_iter("a1bbb2").collect::<Vec<_>>();
         assert_eq!(ms, vec![(0, 0), (1, 2), (3, 3), (4, 4), (5, 6)]);
+    }
+
+    #[test]
+    fn test_zero_length_matches_jumps_past_match_location() {
+        let re = Regex::new(r"\b").unwrap();
+        let matches = re.find_iter("test string").collect::<Vec<_>>();
+        assert_eq!(matches, [(0, 0), (4, 4), (5, 5), (11, 11)]);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! }
 //! ```
 
-#![feature(pattern)]
+#![cfg_attr(feature = "std-pattern", feature(pattern))]
 
 #[macro_use]
 extern crate bitflags;
@@ -34,6 +34,8 @@ mod names;
 mod syntax;
 mod tree;
 mod utils;
+
+#[cfg(feature="std-pattern")]
 mod pattern;
 
 // re-export the onig types publically

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@
 //! }
 //! ```
 
+#![feature(pattern)]
+
 #[macro_use]
 extern crate bitflags;
 #[macro_use]
@@ -32,6 +34,7 @@ mod names;
 mod syntax;
 mod tree;
 mod utils;
+mod pattern;
 
 // re-export the onig types publically
 pub use flags::*;

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -1,0 +1,175 @@
+use std::str::pattern::{Pattern, Searcher, SearchStep};
+use super::{Regex};
+
+/// Regex Searcher Type
+///
+/// Represents the state of an ongoing search over a given string
+/// slice.
+pub struct RegexSearcher<'a> {
+    reg: Regex,
+    pos: usize,
+    hay: &'a str,
+    cached_match: Option<(usize, usize)>
+}
+
+impl<'a> Pattern<'a> for Regex {
+
+    /// Searcher Type
+    ///
+    /// The searcher is the type responsible for returning an iterator
+    /// of matches in a given string
+    type Searcher = RegexSearcher<'a>;
+
+    /// Into Searcher
+    ///
+    /// Creates a new searcher instance from this `Regex` pattern
+    fn into_searcher(self, haystack: &'a str) -> Self::Searcher {
+        RegexSearcher::new(self, haystack)
+    }
+}
+
+impl<'a> RegexSearcher<'a> {
+
+    /// New
+    ///
+    /// Create a regex searcher which uses the given regex to search a
+    /// given pattern.
+    pub fn new(reg: Regex, haystack: &'a str) -> Self {
+        RegexSearcher::<'a> {
+            reg: reg,
+            pos: 0,
+            hay: haystack,
+            cached_match: None
+        }
+    }
+}
+
+unsafe impl<'a> Searcher<'a> for RegexSearcher<'a> {
+
+    /// Haystack Accessor
+    ///
+    /// Return the contained reference to the haystack being searched.
+    fn haystack(&self) -> &'a str {
+        self.hay
+    }
+
+    /// Next
+    ///
+    /// Returns the indexes of the next `Match` or `Reject` of the
+    /// pattern within the haystack.
+    fn next(&mut self) -> SearchStep {
+
+        // if we have a cached match then return it straight away
+        if let Some((start, end)) = self.cached_match {
+            self.cached_match = None;
+            self.pos = end;
+            return SearchStep::Match(start, end);
+        }
+
+        // If we have no more haystack to search, we are done
+        if self.pos >= self.hay.len() {
+            return SearchStep::Done;
+        }
+
+        // Search based on the current position
+        let next = self.reg.find(&self.hay[self.pos..])
+            .map(|p| {
+                let (start, end) = p;
+                (start + self.pos, end + self.pos)
+            });
+        
+        match next {
+            // we found a new match at the beginning of our slice, so
+            // just return it straight away
+            Some((start, end)) if start == self.pos => {
+                self.pos = end;
+                SearchStep::Match(start, end)
+            }
+            // We found a match later on in the slice. So cache it for
+            // now and return a rejection up to the start of the
+            // match
+            Some((start, _)) => {
+                self.cached_match = next;
+                SearchStep::Reject(self.pos, start)
+            }
+            // We didn't find anything in the remainder of the
+            // slice. So issue a rejection for the remaining buffer
+            None => {
+                let old_pos = self.pos;
+                self.pos = self.hay.len();
+                SearchStep::Reject(old_pos, self.pos)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ::Regex;
+    use std::str::pattern::{Pattern, Searcher, SearchStep};
+
+    #[test]
+    pub fn pattern_matches_in_str_returns_all_matches() {
+        {
+            let pattern = Regex::new("abc").unwrap();
+            let v: Vec<&str> = "abcXXXabcYYYabc".matches(pattern).collect();
+            assert_eq!(v, ["abc", "abc", "abc"]);
+        }
+        {
+            let pattern = Regex::new("a+").unwrap();
+            let v: Vec<&str> = ".a..aaa.a".matches(pattern).collect();
+            assert_eq!(v, ["a", "aaa", "a"]);
+        }
+    }
+
+    #[test]
+    pub fn pattern_matches_with_index_returns_all_matches() {
+        let pattern = Regex::new("[0-9]+").unwrap();
+        let v: Vec<(usize, &str)> =
+            "hello 1234 12.34 3".match_indices(pattern).collect();
+        assert_eq!(v, [(6, "1234"), (11, "12"), (14, "34"), (17, "3")]);
+    }
+
+    #[test]
+    pub fn pattern_trim_matches_removes_matches() {
+        {
+            let pattern = Regex::new("a+").unwrap();
+            let trimmed = "aaaaworld".trim_left_matches(pattern);
+            assert_eq!(trimmed, "world");
+        }
+        {
+            let pattern = Regex::new("[ab]").unwrap();
+            let trimmed = "aabbbababtbaest".trim_left_matches(pattern);
+            assert_eq!(trimmed, "tbaest");
+        }
+        {
+            let pattern = Regex::new(r#"[ \t]"#).unwrap();
+            let trimmed = "   \t".trim_left_matches(pattern);
+            assert_eq!(trimmed, "");
+        }
+    }
+
+    #[test]
+    pub fn pattern_as_searcher_returns_expected_rejections() {
+        {
+            let mut searcher = Regex::new("[ab]").unwrap().into_searcher("a.b");
+            assert_eq!(searcher.next(), SearchStep::Match(0, 1));
+            assert_eq!(searcher.next(), SearchStep::Reject(1, 2));
+            assert_eq!(searcher.next(), SearchStep::Match(2, 3));
+            assert_eq!(searcher.next(), SearchStep::Done);
+        }
+        {
+            let mut searcher = Regex::new("test").unwrap().into_searcher("this test string");
+            assert_eq!(searcher.next(), SearchStep::Reject(0, 5));
+            assert_eq!(searcher.next(), SearchStep::Match(5, 9));
+            assert_eq!(searcher.next(), SearchStep::Reject(9, 16));
+            assert_eq!(searcher.next(), SearchStep::Done);
+        }
+    }
+
+    #[test]
+    pub fn pattern_match_prefix_returns_true_when_regex_is_prefix() {
+        let pattern = Regex::new("a+").unwrap();
+        assert!(pattern.is_prefix_of("aaaaaworld"));
+    }
+}


### PR DESCRIPTION
This allows the `onig::Regex` to be used with the `std::str::pattern`
API. `Pattern`s can be used to find a list of matches within a string,
to find prefixes, to check the existence of a substring and to trim
strings.

This implementation is probably a bit rough around the edges. I'd have
liked to have used the existing `RegexMatchs` iterator but couldn't due
to the ownership requirements of the `Pattern` trait.

Still TODO:

 * [x] Work getting this to build on stable. Will prbbably require a feature
   switch.
 * [x] See how well we handle empty patterns when queried for matches.

completes #13  