### PR TITLE
Add Iterator Implementation for Region

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Cargo.lock
 target/
 *.rs.bk
 .vagrant/
+*.orig


### PR DESCRIPTION
Iterating a region will yield each of the captures in the region. Not sure how much use this is, but it could come in useful when implementing iteration in the `Captures` object