### PR TITLE
Add Encoding Support to Regex new - Incomplete

### DIFF
--- a/src/buffers.rs
+++ b/src/buffers.rs
@@ -1,0 +1,43 @@
+//! Encoded Buffers Implementation
+//!
+//! This module contains a trait used for converting byte buffers or
+//! Rust strings into oniguruma char buffers to search and compile
+//! with.
+
+use onig_sys;
+
+/// Encoded String Buffer
+///
+/// Represents a buffer of characters with encoding information
+/// attached.
+pub trait EncodedStringBuffer {
+
+    /// Pointer to the start of the pattern
+    ///
+    /// This should point to the first character in the buffer,
+    /// encoded as an `onig_sys` character.
+    fn start_ptr(&self) -> *const onig_sys::OnigUChar;
+
+    /// Pointer to the limit of the pattern buffer
+    ///
+    /// This should point just past the final character in the buffer,
+    /// encoded as an `onig_sys` character.
+    fn limit_ptr(&self) -> *const onig_sys::OnigUChar;
+
+    /// The encoding of the contents of the buffer
+    fn encoding(&self) -> onig_sys::OnigEncoding {
+        &onig_sys::OnigEncodingUTF8
+    }
+}
+
+impl <T> EncodedStringBuffer for T where T : AsRef<str> {
+
+    fn start_ptr(&self) -> *const onig_sys::OnigUChar {
+        self.as_ref().as_bytes().as_ptr()
+    }
+
+    fn limit_ptr(&self) -> *const onig_sys::OnigUChar {
+        let bytes = self.as_ref().as_bytes();
+        bytes[bytes.len()..].as_ptr()
+    }
+}

--- a/src/buffers.rs
+++ b/src/buffers.rs
@@ -10,7 +10,7 @@ use onig_sys;
 ///
 /// Represents a buffer of characters with encoding information
 /// attached.
-pub trait EncodedStringBuffer {
+pub trait EncodedChars {
 
     /// Pointer to the start of the pattern
     ///
@@ -30,7 +30,7 @@ pub trait EncodedStringBuffer {
     }
 }
 
-impl <T> EncodedStringBuffer for T where T: AsRef<str> {
+impl <T> EncodedChars for T where T: AsRef<str> {
 
     fn start_ptr(&self) -> *const onig_sys::OnigUChar {
         self.as_ref().as_bytes().as_ptr()
@@ -45,12 +45,12 @@ impl <T> EncodedStringBuffer for T where T: AsRef<str> {
 /// Byte Buffer
 ///
 /// Represents a buffer of bytes, with an encoding.
-pub struct ByteBuffer<'a> {
+pub struct EncodedBytes<'a> {
     bytes: &'a[u8],
     enc: onig_sys::OnigEncoding
 }
 
-impl<'a> ByteBuffer<'a> {
+impl<'a> EncodedBytes<'a> {
 
     /// New Buffer from Parts
     ///
@@ -62,8 +62,8 @@ impl<'a> ByteBuffer<'a> {
     /// # Returns
     ///
     /// A new buffer instance
-    pub fn from_parts(bytes: &'a[u8], enc: onig_sys::OnigEncoding) -> ByteBuffer<'a> {
-        ByteBuffer {
+    pub fn from_parts(bytes: &'a[u8], enc: onig_sys::OnigEncoding) -> EncodedBytes<'a> {
+        EncodedBytes {
             bytes: bytes,
             enc: enc
         }
@@ -78,15 +78,15 @@ impl<'a> ByteBuffer<'a> {
     /// # Returns
     ///
     /// A new buffer instance
-    pub fn ascii(bytes: &'a[u8]) -> ByteBuffer<'a> {
-        ByteBuffer {
+    pub fn ascii(bytes: &'a[u8]) -> EncodedBytes<'a> {
+        EncodedBytes {
             bytes: bytes,
             enc: &onig_sys::OnigEncodingASCII
         }
     }
 }
 
-impl<'a> EncodedStringBuffer for ByteBuffer<'a> {
+impl<'a> EncodedChars for EncodedBytes<'a> {
 
     fn start_ptr(&self) -> *const onig_sys::OnigUChar {
         self.bytes.as_ptr()
@@ -120,7 +120,7 @@ pub mod tests {
     #[test]
     pub fn rust_bytes_encoding_is_ascii() {
         let fizz = b"fizz";
-        let buff = ByteBuffer::ascii(fizz);
+        let buff = EncodedBytes::ascii(fizz);
         assert_eq!(&onig_sys::OnigEncodingASCII as onig_sys::OnigEncoding, buff.encoding());
     }
 
@@ -133,14 +133,14 @@ pub mod tests {
     #[test]
     pub fn rust_bytes_ptr_offsets_are_valid() {
         let fozz = b"foo.*bar";
-        let buff = ByteBuffer::ascii(fozz);
+        let buff = EncodedBytes::ascii(fozz);
         assert_eq!(buff.limit_ptr() as usize - buff.start_ptr() as usize, fozz.len());
     }
 
     #[test]
     pub fn byte_buffer_create() {
         let buff = b"hello world";
-        let enc_buffer = ByteBuffer::from_parts(buff, &onig_sys::OnigEncodingASCII);
+        let enc_buffer = EncodedBytes::from_parts(buff, &onig_sys::OnigEncodingASCII);
         assert_eq!(&onig_sys::OnigEncodingASCII as onig_sys::OnigEncoding, enc_buffer.encoding());
         assert_eq!(enc_buffer.limit_ptr() as usize - enc_buffer.start_ptr() as usize, buff.len());
     }

--- a/src/buffers.rs
+++ b/src/buffers.rs
@@ -28,6 +28,8 @@ pub trait EncodedChars {
     fn encoding(&self) -> onig_sys::OnigEncoding {
         &onig_sys::OnigEncodingUTF8
     }
+
+    fn len(&self) -> usize;
 }
 
 impl <T> EncodedChars for T where T: AsRef<str> {
@@ -39,6 +41,10 @@ impl <T> EncodedChars for T where T: AsRef<str> {
     fn limit_ptr(&self) -> *const onig_sys::OnigUChar {
         let bytes = self.as_ref().as_bytes();
         bytes[bytes.len()..].as_ptr()
+    }
+
+    fn len(&self) -> usize {
+        self.as_ref().len()
     }
 }
 
@@ -98,6 +104,10 @@ impl<'a> EncodedChars for EncodedBytes<'a> {
 
     fn encoding(&self) -> onig_sys::OnigEncoding {
         self.enc
+    }
+
+    fn len(&self) -> usize {
+        self.bytes.len()
     }
 }
 

--- a/src/buffers.rs
+++ b/src/buffers.rs
@@ -30,7 +30,7 @@ pub trait EncodedStringBuffer {
     }
 }
 
-impl <T> EncodedStringBuffer for T where T : AsRef<str> {
+impl <T> EncodedStringBuffer for T where T: AsRef<str> {
 
     fn start_ptr(&self) -> *const onig_sys::OnigUChar {
         self.as_ref().as_bytes().as_ptr()
@@ -39,5 +39,109 @@ impl <T> EncodedStringBuffer for T where T : AsRef<str> {
     fn limit_ptr(&self) -> *const onig_sys::OnigUChar {
         let bytes = self.as_ref().as_bytes();
         bytes[bytes.len()..].as_ptr()
+    }
+}
+
+/// Byte Buffer
+///
+/// Represents a buffer of bytes, with an encoding.
+pub struct ByteBuffer<'a> {
+    bytes: &'a[u8],
+    enc: onig_sys::OnigEncoding
+}
+
+impl<'a> ByteBuffer<'a> {
+
+    /// New Buffer from Parts
+    ///
+    /// # Arguments
+    ///
+    ///  * `bytes` - The contents of the buffer
+    ///  * `enc` - The encoding this buffer is in
+    ///
+    /// # Returns
+    ///
+    /// A new buffer instance
+    pub fn from_parts(bytes: &'a[u8], enc: onig_sys::OnigEncoding) -> ByteBuffer<'a> {
+        ByteBuffer {
+            bytes: bytes,
+            enc: enc
+        }
+    }
+
+    /// New ASCII Buffer
+    ///
+    /// # Arguments
+    ///
+    ///  * `bytes` - The ASCII encoded string
+    ///
+    /// # Returns
+    ///
+    /// A new buffer instance
+    pub fn ascii(bytes: &'a[u8]) -> ByteBuffer<'a> {
+        ByteBuffer {
+            bytes: bytes,
+            enc: &onig_sys::OnigEncodingASCII
+        }
+    }
+}
+
+impl<'a> EncodedStringBuffer for ByteBuffer<'a> {
+
+    fn start_ptr(&self) -> *const onig_sys::OnigUChar {
+        self.bytes.as_ptr()
+    }
+
+    fn limit_ptr(&self) -> *const onig_sys::OnigUChar {
+        self.bytes[self.bytes.len()..].as_ptr()
+    }
+
+    fn encoding(&self) -> onig_sys::OnigEncoding {
+        self.enc
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+
+    use onig_sys;
+
+    use super::*;
+
+    #[test]
+    pub fn rust_string_encoding_is_utf8() {
+        let foo = "foo";
+        assert_eq!(&onig_sys::OnigEncodingUTF8 as onig_sys::OnigEncoding, foo.encoding());
+
+        let bar = String::from(".*");
+        assert_eq!(&onig_sys::OnigEncodingUTF8 as onig_sys::OnigEncoding, bar.encoding());
+    }
+
+    #[test]
+    pub fn rust_bytes_encoding_is_ascii() {
+        let fizz = b"fizz";
+        let buff = ByteBuffer::ascii(fizz);
+        assert_eq!(&onig_sys::OnigEncodingASCII as onig_sys::OnigEncoding, buff.encoding());
+    }
+
+    #[test]
+    pub fn rust_string_ptr_offsets_are_valid() {
+        let test_string = "hello world";
+        assert_eq!(test_string.limit_ptr() as usize - test_string.start_ptr() as usize, test_string.len());
+    }
+
+    #[test]
+    pub fn rust_bytes_ptr_offsets_are_valid() {
+        let fozz = b"foo.*bar";
+        let buff = ByteBuffer::ascii(fozz);
+        assert_eq!(buff.limit_ptr() as usize - buff.start_ptr() as usize, fozz.len());
+    }
+
+    #[test]
+    pub fn byte_buffer_create() {
+        let buff = b"hello world";
+        let enc_buffer = ByteBuffer::from_parts(buff, &onig_sys::OnigEncodingASCII);
+        assert_eq!(&onig_sys::OnigEncodingASCII as onig_sys::OnigEncoding, enc_buffer.encoding());
+        assert_eq!(enc_buffer.limit_ptr() as usize - enc_buffer.start_ptr() as usize, buff.len());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,9 +152,11 @@ impl Regex {
     /// # Examples
     ///
     /// ```
-    /// use onig::Regex;
-    /// let r = Regex::with_encoding(r#"hello (\w+)"#);
-    /// assert!(r.is_ok());
+    /// use onig::{Regex, ByteBuffer};
+    /// let utf8 = Regex::with_encoding("hello");
+    /// assert!(utf8.is_ok());
+    /// let ascii = Regex::with_encoding(ByteBuffer::ascii(b"world"));
+    /// assert!(ascii.is_ok());
     /// ```
     pub fn with_encoding<T>(pattern: T) -> Result<Regex, Error>
         where T: EncodedStringBuffer
@@ -212,8 +214,9 @@ impl Regex {
     ///
     /// # Examples
     /// ```
-    /// use onig::{Regex, Syntax, REGEX_OPTION_SINGLELINE};
-    /// let r = Regex::with_options_and_encoding("hello",
+    /// use onig::{Regex, Syntax, ByteBuffer, REGEX_OPTION_SINGLELINE};
+    /// let pattern = ByteBuffer::ascii(b"hello");
+    /// let r = Regex::with_options_and_encoding(pattern,
     ///                                          REGEX_OPTION_SINGLELINE,
     ///                                          Syntax::default());
     /// assert!(r.is_ok());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -485,18 +485,47 @@ impl Regex {
             .unwrap_or(false)
     }
 
-    /// Returns the start and end byte range of the leftmost-first match in
-    /// `text`. If no match exists, then `None` is returned.
+    /// Find a Match in a Buffer, With Encoding
+    ///
+    /// Finds the first match of the regular expression within the
+    /// buffer.
     ///
     /// Note that this should only be used if you want to discover the position
     /// of the match. Testing the existence of a match is faster if you use
     /// `is_match`.
+    ///
+    /// # Arguments
+    ///  * `text` - The text to search in.
+    ///
+    /// # Returns
+    ///
+    ///  The offset of the start and end of the first match. If no
+    ///  match exists `None` is returned.
     pub fn find(&self, text: &str) -> Option<(usize, usize)> {
-        let mut region = Region::new();
-        self.search_with_options(text, 0, text.len(), SEARCH_OPTION_NONE, Some(&mut region))
-            .map(|_| region.pos(0))
-            .unwrap_or(None)
+        self.find_with_encoding(text)
     }
+
+    /// Find a Match in a Buffer, With Encoding
+    ///
+    /// Finds the first match of the regular expression within the
+    /// buffer.
+    ///
+    /// # Arguments
+    ///  * `text` - The text to search in.
+    ///
+    /// # Returns
+    ///
+    ///  The offset of the start and end of the first match. If no
+    ///  match exists `None` is returned.
+    pub fn find_with_encoding<T>(&self, text: T) -> Option<(usize, usize)>
+        where T: EncodedChars
+    {
+        let mut region = Region::new();
+        let len = text.len();
+        self.search_with_encoding(text, 0, len, SEARCH_OPTION_NONE, Some(&mut region))
+            .and_then(|_| region.pos(0))
+    }
+
 
     /// Get the Encoding of the Regex
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub use names::CaptureNames;
 pub use region::Region;
 pub use find::{Captures, SubCaptures, SubCapturesPos, FindMatches, FindCaptures, RegexSplits,
                RegexSplitsN};
-pub use buffers::EncodedStringBuffer;
+pub use buffers::{EncodedStringBuffer, ByteBuffer};
 pub use replace::Replacer;
 pub use tree::{CaptureTreeNode, CaptureTreeNodeIter};
 pub use syntax::Syntax;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub use names::CaptureNames;
 pub use region::Region;
 pub use find::{Captures, SubCaptures, SubCapturesPos, FindMatches, FindCaptures, RegexSplits,
                RegexSplitsN};
-pub use buffers::{EncodedStringBuffer, ByteBuffer};
+pub use buffers::{EncodedChars, EncodedBytes};
 pub use replace::Replacer;
 pub use tree::{CaptureTreeNode, CaptureTreeNodeIter};
 pub use syntax::Syntax;
@@ -152,14 +152,14 @@ impl Regex {
     /// # Examples
     ///
     /// ```
-    /// use onig::{Regex, ByteBuffer};
+    /// use onig::{Regex, EncodedBytes};
     /// let utf8 = Regex::with_encoding("hello");
     /// assert!(utf8.is_ok());
-    /// let ascii = Regex::with_encoding(ByteBuffer::ascii(b"world"));
+    /// let ascii = Regex::with_encoding(EncodedBytes::ascii(b"world"));
     /// assert!(ascii.is_ok());
     /// ```
     pub fn with_encoding<T>(pattern: T) -> Result<Regex, Error>
-        where T: EncodedStringBuffer
+        where T: EncodedChars
     {
         Regex::with_options_and_encoding(pattern, REGEX_OPTION_NONE, Syntax::default())
     }
@@ -214,8 +214,8 @@ impl Regex {
     ///
     /// # Examples
     /// ```
-    /// use onig::{Regex, Syntax, ByteBuffer, REGEX_OPTION_SINGLELINE};
-    /// let pattern = ByteBuffer::ascii(b"hello");
+    /// use onig::{Regex, Syntax, EncodedBytes, REGEX_OPTION_SINGLELINE};
+    /// let pattern = EncodedBytes::ascii(b"hello");
     /// let r = Regex::with_options_and_encoding(pattern,
     ///                                          REGEX_OPTION_SINGLELINE,
     ///                                          Syntax::default());
@@ -225,7 +225,7 @@ impl Regex {
                            option: RegexOptions,
                            syntax: &Syntax)
                            -> Result<Regex, Error>
-        where T : EncodedStringBuffer
+        where T : EncodedChars
     {
         // Convert the rust types to those required for the call to
         // `onig_new`.


### PR DESCRIPTION
Intorduce a new trait to represent a buffer of bytes with an
encoding. Using this trait define a new set of constructors for `Regex`
which are encoding aware.

Fixes #23 