### PR TITLE
Always Statically Link `onig_sys` on `musl`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,11 @@ libc = "0.2"
 bitflags = "0.7"
 lazy_static = "0.2"
 
-[dependencies.onig_sys]
+[target.'cfg(not(target_env = "musl"))'.dependencies.onig_sys]
 version = "61.1"
 path = "onig_sys"
 
-[target.'cfg(target_env = "musl")'.dependencies]
-onig_sys = { features = [ "static_onig"] }
+[target.'cfg(target_env = "musl")'.dependencies.onig_sys]
+features = [ "static_onig"]
+version = "61.1"
+path = "onig_sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ lazy_static = "0.2"
 [dependencies.onig_sys]
 version = "61.1"
 path = "onig_sys"
+
+[target.'cfg(target_env = "musl")'.dependencies]
+onig_sys = { features = [ "static_onig"] }


### PR DESCRIPTION
Add a target overide for `musl` environments to always enable static linking of libonig.

Fixes #31 