### PR TITLE
Upgrade oniguruma to 6.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ bitflags = "0.7"
 lazy_static = "0.2"
 
 [target.'cfg(not(target_env = "musl"))'.dependencies.onig_sys]
-version = "64.0.1"
+version = "65.0.0"
 path = "onig_sys"
 
 [target.'cfg(target_env = "musl")'.dependencies.onig_sys]
 features = [ "static_onig"]
-version = "64.0.1"
+version = "65.0.0"
 path = "onig_sys"

--- a/onig_sys/Cargo.toml
+++ b/onig_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onig_sys"
-version = "64.0.1"
+version = "65.0.0"
 authors = ["Will Speak <will@willspeak.me>", "Ivan Ivashchenko <defuz@me.com>"]
 build = "build.rs"
 links = "onig"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -51,7 +51,7 @@ mod tests {
     #[test]
     pub fn utils_get_version_returns_expected_version() {
         let version = version();
-        assert_eq!(version, "6.4.0");
+        assert_eq!(version, "6.5.0");
     }
 
     #[test]


### PR DESCRIPTION
https://github.com/kkos/oniguruma/blob/master/HISTORY

> 2017/08/03: Version 6.5.0
>
> 2017/07/30: [new] support Absent clear (Absent functions)
2017/07/25: abolish configure option: --enable-combination-explosion-check
2017/07/23: [new] support Absent functions (?~...)
2017/07/14: fix #65: SIZEOF_SIZE_T doesn't exist on certain architecutres
2017/07/11: [new] support \O (true anychar)
2017/07/10: [new] support \K (keep)
2017/07/10: add new node type: NODE_GIMMICK
2017/07/07: [new] support \N (no newline)
2017/07/05: [new] support \R (general newline)
2017/07/05: [new] support if-then-else syntax
2017/07/04: [new] support backref validity checker