### PR TITLE
Add `LinkType` to Build Script & Default to Static on MSVC

### DIFF
--- a/onig_sys/build.rs
+++ b/onig_sys/build.rs
@@ -75,7 +75,7 @@ fn compile(link_type: LinkType) {
 }
 
 #[cfg(target_env = "msvc")]
-pub fn compile(link_type: LinkType) {
+fn compile(link_type: LinkType) {
     use std::process::Command;
 
     let onig_sys_dir = env::current_dir().unwrap();


### PR DESCRIPTION
All link types can now be overriden with the appropriate environment
vairable too. This should make the defualt use case on Windows (to
statically link) easier.

Fixes #51