### PR TITLE
Switch to Statically Linking by Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ for (i, pos) in regex.captures("hello").unwrap().iter_pos().enumerate() {
 
 ## Static Linking
 
-By default `rust-onig` will be dynamically lined to `libonig`. If your would rather that static linking is used then the environment variable `RUSTONIG_STATIC_LIBONIG` can be set. On *nix:
+By default `rust-onig` will be statically lined to `libonig`. If your would rather that dynamic linking is used then the environment variables `RUSTONIG_STATIC_LIBONIG` and `RUSTONIG_DYNAMIC_LIBONIG` can be set. On *nix:
 
-    $ RUSTONIG_STATIC_LIBONIG=1 cargo build
+    $ RUSTONIG_DYNAMIC_LIBONING=1 cargo build
 
 Or Windows:
 
-    > set RUSTONIG_STATIC_LIBONIG=1
+    > set RUSTONIG_DYNAMIC_LIBONIG=1
     > cargo build
 
 ## Rust-Onig is Open Source

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ for (i, pos) in regex.captures("hello").unwrap().iter_pos().enumerate() {
 }
 ```
 
-## Static Linking
+## Linking
+
+If a version of Oniguruma can be found by `pkg-config` then that will be used. If not then Oniguruma will be compiled from source and linked to the `onig-sys` crate.
 
 By default `rust-onig` will be statically lined to `libonig`. If your would rather that dynamic linking is used then the environment variables `RUSTONIG_STATIC_LIBONIG` and `RUSTONIG_DYNAMIC_LIBONIG` can be set. On *nix:
 


### PR DESCRIPTION
If the library can't be found by `pkg-config` then statically link by
default. This adds a new environment variable
`RUSTONIG_DYNAMIC_LIBONIG` which enables dynamic linking. Linking is
therefore defined by:

* If `RUSTONIG_DYNAMIC_LIBONIG` is set:
  * Dynamic if true
  * Static if false
* If `RUSTONIG_STATIC_LIBONIG` is set:
  * Static if true
  * Dynamic if false
* If neither is set, then static linking is used.

Part of #65. Fixes #63.