### PR TITLE
Feature for debugging Oniguruma parsing/compiling/matching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ license = "MIT"
 
 [features]
 std-pattern = []
+# Make Oniguruma print debug output for parsing/compiling and executing
+print-debug = ["onig_sys/print-debug"]
 
 [dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ Or Windows:
     > set RUSTONIG_DYNAMIC_LIBONIG=1
     > cargo build
 
+## Debugging
+
+Sometimes it's useful to debug how Oniguruma parses, compiles, optimizes or
+executes a particular pattern.
+
+When activating the `print-debug` feature for this crate, Oniguruma is compiled
+with debugging. Note that it's a compile-time setting, so you also need to make
+`rust-onig` not use the system Oniguruma by using `RUSTONIG_SYSTEM_LIBONIG`.
+
+With all that combined, here's an example command to debug the pattern `a|b`:
+
+    RUSTONIG_SYSTEM_LIBONIG=0 cargo run --features print-debug --example capturedump 'a|b'
+
 ## Rust-Onig is Open Source
 
 The contents of this repository are distributed under the MIT license. See [LICENSE](LICENSE.md) for more details.

--- a/onig_sys/Cargo.toml
+++ b/onig_sys/Cargo.toml
@@ -28,3 +28,7 @@ version = "0.9.2"
 
 [target.'cfg(not(target_env="msvc"))'.build-dependencies.cmake]
 version = "0.1"
+
+[features]
+# Make Oniguruma print debug output for parsing/compiling and executing
+print-debug = []

--- a/onig_sys/build.rs
+++ b/onig_sys/build.rs
@@ -75,6 +75,13 @@ fn compile(link_type: LinkType) {
     // into $OUT_DIR
     let mut c = Config::new("oniguruma");
 
+    if env_var_bool("CARGO_FEATURE_PRINT_DEBUG").unwrap_or(false) {
+        c.cflag("-DONIG_DEBUG_PARSE=1");
+        c.cflag("-DONIG_DEBUG_COMPILE=1");
+        c.cflag("-DONIG_DEBUG_SEARCH=1");
+        c.cflag("-DONIG_DEBUG_MATCH=1");
+    }
+
     let dst = match link_type {
         LinkType::Static => c.define("BUILD_SHARED_LIBS", "OFF"),
         LinkType::Dynamic => c.define("CMAKE_MACOSX_RPATH", "NO"),


### PR DESCRIPTION
For #72. Split into two commits:

* Allow to disable using system libonig via RUSTONIG_SYSTEM_LIBONIG=0
* Add print-debug feature for debugging Oniguruma

Note that I've only tested this on Mac. Windows uses a different build system, so I'm not sure how to add it there.