### PR TITLE
Six dot eight

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onig"
-version = "3.1.1"
+version = "3.2.0"
 authors = [
         "Will Speak <will@willspeak.me>",
         "Ivan Ivashchenko <defuz@me.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ bitflags = "1.0"
 lazy_static = "1.0"
 
 [dependencies.onig_sys]
-version = "67.1.0"
+version = "68.0.0"
 path = "onig_sys"

--- a/onig_sys/Cargo.toml
+++ b/onig_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onig_sys"
-version = "67.1.0"
+version = "68.0.0"
 authors = ["Will Speak <will@willspeak.me>", "Ivan Ivashchenko <defuz@me.com>"]
 build = "build.rs"
 links = "onig"

--- a/onig_sys/Cargo.toml
+++ b/onig_sys/Cargo.toml
@@ -24,7 +24,7 @@ libc = "0.2"
 pkg-config = "0.3"
 
 [target.'cfg(target_env="msvc")'.build-dependencies.duct]
-version = "0.9.2"
+version = "0.10"
 
 [target.'cfg(not(target_env="msvc"))'.build-dependencies.cmake]
 version = "0.1"

--- a/onig_sys/build.rs
+++ b/onig_sys/build.rs
@@ -36,30 +36,26 @@ impl fmt::Display for LinkType {
 }
 
 fn env_var_bool(name: &str) -> Option<bool> {
-    env::var(name).ok().map(|s|
-        match &s.to_string().to_lowercase()[..] {
+    env::var(name)
+        .ok()
+        .map(|s| match &s.to_string().to_lowercase()[..] {
             "0" | "no" | "false" => false,
             _ => true,
-        }
-    )
+        })
 }
 
 /// # Link Type Override
 ///
 /// Retuns the override from the environment, if any is set.
 fn link_type_override() -> Option<LinkType> {
-    let dynamic_env = env_var_bool("RUSTONIG_DYNAMIC_LIBONIG").map(|b|
-        match b {
-            true => LinkType::Dynamic,
-            false => LinkType::Static,
-        }
-    );
-    let static_env = env_var_bool("RUSTONIG_STATIC_LIBONIG").map(|b|
-         match b {
-             true => LinkType::Static,
-             false => LinkType::Dynamic,
-         }
-    );
+    let dynamic_env = env_var_bool("RUSTONIG_DYNAMIC_LIBONIG").map(|b| match b {
+        true => LinkType::Dynamic,
+        false => LinkType::Static,
+    });
+    let static_env = env_var_bool("RUSTONIG_STATIC_LIBONIG").map(|b| match b {
+        true => LinkType::Static,
+        false => LinkType::Dynamic,
+    });
 
     dynamic_env.or(static_env)
 }
@@ -96,7 +92,6 @@ fn compile(link_type: LinkType) {
 
 #[cfg(target_env = "msvc")]
 fn compile(link_type: LinkType) {
-
     let onig_sys_dir = env::current_dir().unwrap();
     let build_dir = env::var("OUT_DIR").unwrap();
     let lib_name = match link_type {
@@ -129,9 +124,9 @@ fn compile(link_type: LinkType) {
 
 pub fn main() {
     if env_var_bool("RUSTONIG_SYSTEM_LIBONIG").unwrap_or(true) {
-         if let Ok(_) = pkg_config::find_library("oniguruma") {
-             return;
-         }
+        if let Ok(_) = pkg_config::find_library("oniguruma") {
+            return;
+        }
     }
 
     let link_type = link_type_override().unwrap_or(DEFAULT_LINK_TYPE);

--- a/onig_sys/src/constants.rs
+++ b/onig_sys/src/constants.rs
@@ -1,6 +1,6 @@
 use libc::{c_int, c_uint};
-use super::{OnigCtype, OnigOptionType, OnigDistance, OnigCaseFoldType, OnigSyntaxOp,
-            OnigSyntaxOp2, OnigSyntaxBehavior};
+use super::{OnigCaseFoldType, OnigCtype, OnigDistance, OnigOptionType, OnigSyntaxBehavior,
+            OnigSyntaxOp, OnigSyntaxOp2};
 
 macro_rules! define_consts {
     ($typ:ty, $( $name:ident = $value:expr );* ) => {

--- a/onig_sys/src/lib.rs
+++ b/onig_sys/src/lib.rs
@@ -6,7 +6,7 @@ mod onigenc;
 pub use self::constants::*;
 pub use self::onigenc::*;
 
-use libc::{c_int, c_uint, c_void, c_char, c_uchar};
+use libc::{c_char, c_int, c_uchar, c_uint, c_void};
 
 pub type OnigCodePoint = c_uint;
 pub type OnigUChar = c_uchar;
@@ -28,25 +28,18 @@ pub type OnigRegexMut = *mut OnigRegexType;
 pub type OnigWarnFunc = extern "C" fn(*const c_char);
 
 /// Apply All Case Fold Callback, see OnigEncodingType->apply_all_case_fold
-pub type OnigApplyAllCaseFoldFunc = extern "C" fn(from: OnigCodePoint,
-                                                  to: *const OnigCodePoint,
-                                                  to_len: c_int,
-                                                  arg: *const c_void)
-                                                  -> c_int;
-
+pub type OnigApplyAllCaseFoldFunc =
+    extern "C" fn(from: OnigCodePoint, to: *const OnigCodePoint, to_len: c_int, arg: *const c_void)
+        -> c_int;
 
 /// Foreach Callback
 ///
 /// This callback will be invoked for each name when calling
 /// [`onig_foreach_name`](fn.onig_foreach_name.html). The
 /// final argument to that function is passed back to this callback.
-pub type OnigForeachNameCallback = extern "C" fn(*const OnigUChar,
-                                                 *const OnigUChar,
-                                                 c_int,
-                                                 *const c_int,
-                                                 OnigRegex,
-                                                 *mut c_void)
-                                                 -> c_int;
+pub type OnigForeachNameCallback =
+    extern "C" fn(*const OnigUChar, *const OnigUChar, c_int, *const c_int, OnigRegex, *mut c_void)
+        -> c_int;
 
 /// Capture Tree Callback
 ///
@@ -113,7 +106,6 @@ pub struct OnigCompileInfo {
     pub case_fold_flag: OnigCaseFoldType,
 }
 
-
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct OnigMetaCharTableType {
@@ -142,30 +134,29 @@ pub struct OnigEncodingType {
     pub mbc_to_code: extern "C" fn(p: *const OnigUChar, end: *const OnigUChar) -> OnigCodePoint,
     pub code_to_mbclen: extern "C" fn(code: OnigCodePoint) -> c_int,
     pub code_to_mbc: extern "C" fn(code: OnigCodePoint, buf: *mut OnigUChar) -> c_int,
-    pub mbc_case_fold: extern "C" fn(flag: OnigCaseFoldType,
-                                     pp: *const *const OnigUChar,
-                                     end: *const OnigUChar,
-                                     to: *const OnigUChar)
-                                     -> c_int,
-    pub apply_all_case_fold: extern "C" fn(flag: OnigCaseFoldType,
-                                           f: OnigApplyAllCaseFoldFunc,
-                                           arg: *const c_void)
-                                           -> c_int,
-    pub get_case_fold_codes_by_str: extern "C" fn(flag: OnigCaseFoldType,
-                                                  p: *const OnigUChar,
-                                                  end: *const OnigUChar /* ... */)
-                                                  -> c_int,
-    pub property_name_to_ctype: extern "C" fn(enc: OnigEncoding,
-                                              p: *const OnigUChar,
-                                              end: *const OnigUChar)
-                                              -> c_int,
+    pub mbc_case_fold: extern "C" fn(
+        flag: OnigCaseFoldType,
+        pp: *const *const OnigUChar,
+        end: *const OnigUChar,
+        to: *const OnigUChar,
+    ) -> c_int,
+    pub apply_all_case_fold:
+        extern "C" fn(flag: OnigCaseFoldType, f: OnigApplyAllCaseFoldFunc, arg: *const c_void)
+            -> c_int,
+    pub get_case_fold_codes_by_str: extern "C" fn(
+        flag: OnigCaseFoldType,
+        p: *const OnigUChar,
+        end: *const OnigUChar, /* ... */
+    ) -> c_int,
+    pub property_name_to_ctype:
+        extern "C" fn(enc: OnigEncoding, p: *const OnigUChar, end: *const OnigUChar) -> c_int,
     pub is_code_ctype: extern "C" fn(code: OnigCodePoint, ctype: OnigCtype) -> c_int,
-    pub get_ctype_code_range: extern "C" fn(ctype: OnigCtype,
-                                            sb_out: *const OnigCodePoint /* ... */)
-                                            -> c_int,
-    pub left_adjust_char_head: extern "C" fn(start: *const OnigUChar, p: *const OnigUChar)
-                                             -> *const OnigUChar,
-    pub is_allowed_reverse_match: extern "C" fn(p: *const OnigUChar, end: *const OnigUChar) -> c_int,
+    pub get_ctype_code_range:
+        extern "C" fn(ctype: OnigCtype, sb_out: *const OnigCodePoint /* ... */) -> c_int,
+    pub left_adjust_char_head:
+        extern "C" fn(start: *const OnigUChar, p: *const OnigUChar) -> *const OnigUChar,
+    pub is_allowed_reverse_match:
+        extern "C" fn(p: *const OnigUChar, end: *const OnigUChar) -> c_int,
     pub init: extern "C" fn() -> c_int,
     pub is_initialised: extern "C" fn() -> c_int,
 }
@@ -189,17 +180,17 @@ pub struct OnigRepeatRange {
 pub struct OnigRegexType {
     // common members of BBuf(bytes-buffer)
     pub p: *const OnigUChar, // compiled pattern
-    pub used: c_uint, // used space for p
-    pub alloc: c_uint, // allocated space for p
+    pub used: c_uint,        // used space for p
+    pub alloc: c_uint,       // allocated space for p
 
-    pub num_mem: c_int, // used memory(...) num counted from 1
-    pub num_repeat: c_int, // OP_REPEAT/OP_REPEAT_NG id-counter
-    pub num_null_check: c_int, // OP_NULL_CHECK_START/END id counter
+    pub num_mem: c_int,            // used memory(...) num counted from 1
+    pub num_repeat: c_int,         // OP_REPEAT/OP_REPEAT_NG id-counter
+    pub num_null_check: c_int,     // OP_NULL_CHECK_START/END id counter
     pub num_comb_exp_check: c_int, // combination explosion check
-    pub num_call: c_int, // number of subexp call
-    pub capture_history: c_uint, // (?@...) flag (1-31)
-    pub bt_mem_start: c_uint, // need backtrack flag
-    pub bt_mem_end: c_uint, // need backtrack flag
+    pub num_call: c_int,           // number of subexp call
+    pub capture_history: c_uint,   // (?@...) flag (1-31)
+    pub bt_mem_start: c_uint,      // need backtrack flag
+    pub bt_mem_end: c_uint,        // need backtrack flag
     pub stack_pop_level: c_int,
     pub repeat_range_alloc: c_int,
     pub repeat_range: *const OnigRepeatRange,
@@ -211,19 +202,19 @@ pub struct OnigRegexType {
     pub name_table: *const c_void,
 
     // optimization info (string search, char-map and anchors)
-    pub optimize: c_int, // optimize flag
-    pub threshold_len: c_int, // search str-length for apply optimize
-    pub anchor: c_int, // BEGIN_BUF, BEGIN_POS, (SEMI_)END_BUF
+    pub optimize: c_int,           // optimize flag
+    pub threshold_len: c_int,      // search str-length for apply optimize
+    pub anchor: c_int,             // BEGIN_BUF, BEGIN_POS, (SEMI_)END_BUF
     pub anchor_dmin: OnigDistance, // (SEMI_)END_BUF anchor distance
     pub anchor_dmax: OnigDistance, // (SEMI_)END_BUF anchor distance
-    pub sub_anchor: c_int, // start-anchor for exact or map
+    pub sub_anchor: c_int,         // start-anchor for exact or map
     pub exact: *const OnigUChar,
     pub exact_end: *const OnigUChar,
     pub map: [OnigUChar; ONIG_CHAR_TABLE_SIZE as usize], // used as BM skip or char-map
-    pub int_map: *const c_int, // BM skip for exact_len > 255
-    pub int_map_backward: *const c_int, // BM skip for backward search
-    pub dmin: OnigDistance, // min-distance of exact or map
-    pub dmax: OnigDistance, // max-distance of exact or map
+    pub int_map: *const c_int,                           // BM skip for exact_len > 255
+    pub int_map_backward: *const c_int,                  // BM skip for backward search
+    pub dmin: OnigDistance,                              // min-distance of exact or map
+    pub dmax: OnigDistance,                              // max-distance of exact or map
 
     pub chain: *const OnigRegexType,
 }
@@ -411,7 +402,7 @@ extern "C" {
     ///  * ONIG_ENCODING_CP1251        CP1251
     ///  * ONIG_ENCODING_BIG5          Big5
     ///  * ONIG_ENCODING_GB18030       GB18030
-    ///  
+    ///
     ///  or any OnigEncoding data address defined by user.
     ///
     /// 6. `syntax`:     address of pattern syntax definition.
@@ -434,14 +425,15 @@ extern "C" {
     /// 7. `err_info`: address for return optional error info.
     ///  Use this value as 3rd argument of onig_error_code_to_str().
     ///
-    pub fn onig_new(reg: *mut OnigRegexMut,
-                    pattern: *const OnigUChar,
-                    pattern_end: *const OnigUChar,
-                    option: OnigOptionType,
-                    enc: OnigEncoding,
-                    syntax: *const OnigSyntaxType,
-                    err_info: *mut OnigErrorInfo)
-                    -> c_int;
+    pub fn onig_new(
+        reg: *mut OnigRegexMut,
+        pattern: *const OnigUChar,
+        pattern_end: *const OnigUChar,
+        option: OnigOptionType,
+        enc: OnigEncoding,
+        syntax: *const OnigSyntaxType,
+        err_info: *mut OnigErrorInfo,
+    ) -> c_int;
 
     /// Onig Reg Init
     ///
@@ -452,12 +444,13 @@ extern "C" {
     ///                    OnigEncoding enc,
     ///                    OnigSyntaxType* syntax);
     /// ```
-    pub fn onig_reg_init(reg: OnigRegexMut,
-                         option: OnigOptionType,
-                         case_fold_flag: OnigCaseFoldType,
-                         enc: OnigEncoding,
-                         syntax: *const OnigSyntaxType)
-                         -> c_int;
+    pub fn onig_reg_init(
+        reg: OnigRegexMut,
+        option: OnigOptionType,
+        case_fold_flag: OnigCaseFoldType,
+        enc: OnigEncoding,
+        syntax: *const OnigSyntaxType,
+    ) -> c_int;
 
     ///   Create a regex object.
     ///   reg object area is not allocated in this function.
@@ -468,14 +461,15 @@ extern "C" {
     ///             OnigErrorInfo* err_info)`
     ///
     ///   normal return: ONIG_NORMAL
-    pub fn onig_new_without_alloc(reg: OnigRegexMut,
-                                  pattern: *const OnigUChar,
-                                  pattern_end: *const OnigUChar,
-                                  option: OnigOptionType,
-                                  enc: OnigEncoding,
-                                  syntax: *const OnigSyntaxType,
-                                  err_info: *mut OnigErrorInfo)
-                                  -> c_int;
+    pub fn onig_new_without_alloc(
+        reg: OnigRegexMut,
+        pattern: *const OnigUChar,
+        pattern_end: *const OnigUChar,
+        option: OnigOptionType,
+        enc: OnigEncoding,
+        syntax: *const OnigSyntaxType,
+        err_info: *mut OnigErrorInfo,
+    ) -> c_int;
 
     ///   Create a regex object.
     ///   This function is deluxe version of onig_new().
@@ -517,12 +511,13 @@ extern "C" {
     ///
     ///     pattern_enc: UTF32_BE/LE
     ///     target_enc:  UTF32_LE/BE
-    pub fn onig_new_deluxe(reg: *mut OnigRegexMut,
-                           pattern: *const OnigUChar,
-                           pattern_end: *const OnigUChar,
-                           ci: *const OnigCompileInfo,
-                           einfo: *mut OnigErrorInfo)
-                           -> c_int;
+    pub fn onig_new_deluxe(
+        reg: *mut OnigRegexMut,
+        pattern: *const OnigUChar,
+        pattern_end: *const OnigUChar,
+        ci: *const OnigCompileInfo,
+        einfo: *mut OnigErrorInfo,
+    ) -> c_int;
 
     ///   Free memory used by regex object.
     ///
@@ -540,7 +535,6 @@ extern "C" {
     ///   arguments
     ///   1 reg: regex object.
     pub fn onig_free_body(reg: OnigRegexMut);
-
 
     /// Allocate a OnigMatchParam object and initialize the contents by
     /// onig_initialize_match_param().
@@ -570,7 +564,10 @@ extern "C" {
     /// 2 limit: number of limit
     ///
     /// normal return: ONIG_NORMAL
-    pub fn onig_set_match_stack_limit_size_of_match_param(mp: *mut OnigMatchParam, limit: c_uint) -> c_int;
+    pub fn onig_set_match_stack_limit_size_of_match_param(
+        mp: *mut OnigMatchParam,
+        limit: c_uint,
+    ) -> c_int;
 
     /// Set a retry limit count of a match process.
     ///
@@ -636,14 +633,15 @@ extern "C" {
     ///    * ONIG_OPTION_NOTBOL        string head(str) isn't considered as begin of line
     ///    * ONIG_OPTION_NOTEOL        string end (end) isn't considered as end of line
     ///    * ONIG_OPTION_POSIX_REGION  region argument is regmatch_t[] of POSIX API.
-    pub fn onig_search(reg: OnigRegex,
-                       str: *const OnigUChar,
-                       end: *const OnigUChar,
-                       start: *const OnigUChar,
-                       range: *const OnigUChar,
-                       region: *mut OnigRegion,
-                       option: OnigOptionType)
-                       -> c_int;
+    pub fn onig_search(
+        reg: OnigRegex,
+        str: *const OnigUChar,
+        end: *const OnigUChar,
+        start: *const OnigUChar,
+        range: *const OnigUChar,
+        region: *mut OnigRegion,
+        option: OnigOptionType,
+    ) -> c_int;
 
     ///   Search string and return search result and matching region.
     ///
@@ -660,15 +658,16 @@ extern "C" {
     ///
     ///   1-7:  same as onig_search()
     ///   8. `mp`: match parameters
-    pub fn onig_search_with_param(reg: OnigRegex,
-                                  str: *const OnigUChar,
-                                  end: *const OnigUChar,
-                                  start: *const OnigUChar,
-                                  range: *const OnigUChar,
-                                  region: *mut OnigRegion,
-                                  option: OnigOptionType,
-                                  mp: *const OnigMatchParam)
-                                  -> c_int;
+    pub fn onig_search_with_param(
+        reg: OnigRegex,
+        str: *const OnigUChar,
+        end: *const OnigUChar,
+        start: *const OnigUChar,
+        range: *const OnigUChar,
+        region: *mut OnigRegion,
+        option: OnigOptionType,
+        mp: *const OnigMatchParam,
+    ) -> c_int;
 
     ///   Match string and return result and matching region.
     ///
@@ -692,13 +691,14 @@ extern "C" {
     ///    * ONIG_OPTION_NOTBOL       string head(str) isn't considered as begin of line
     ///    * ONIG_OPTION_NOTEOL       string end (end) isn't considered as end of line
     ///    * ONIG_OPTION_POSIX_REGION region argument is regmatch_t[] type of POSIX API.
-    pub fn onig_match(reg: OnigRegex,
-                      str: *const OnigUChar,
-                      end: *const OnigUChar,
-                      at: *const OnigUChar,
-                      region: *mut OnigRegion,
-                      option: OnigOptionType)
-                      -> c_int;
+    pub fn onig_match(
+        reg: OnigRegex,
+        str: *const OnigUChar,
+        end: *const OnigUChar,
+        at: *const OnigUChar,
+        region: *mut OnigRegion,
+        option: OnigOptionType,
+    ) -> c_int;
 
     ///   Match string and return result and matching region.
     ///
@@ -715,14 +715,15 @@ extern "C" {
     ///
     ///   1-6:  same as onig_match()
     ///   7. `mp`: match parameters
-    pub fn onig_match_with_param(reg: OnigRegex,
-                      str: *const OnigUChar,
-                      end: *const OnigUChar,
-                      at: *const OnigUChar,
-                      region: *mut OnigRegion,
-                      option: OnigOptionType,
-                      mp: *const OnigMatchParam)
-                      -> c_int;
+    pub fn onig_match_with_param(
+        reg: OnigRegex,
+        str: *const OnigUChar,
+        end: *const OnigUChar,
+        at: *const OnigUChar,
+        region: *mut OnigRegion,
+        option: OnigOptionType,
+        mp: *const OnigMatchParam,
+    ) -> c_int;
 
     ///   Scan string and callback with matching region.
     ///
@@ -738,14 +739,15 @@ extern "C" {
     ///   5 option: search time option
     ///   6 scan_callback: callback function (defined by user)
     ///   7 callback_arg:  optional argument passed to callback
-    pub fn onig_scan(reg: OnigRegex,
-                     str: *const OnigUChar,
-                     end: *const OnigUChar,
-                     region: *mut OnigRegion,
-                     options: OnigOptionType,
-                     scan_callback: OnigScanCallback,
-                     callback_arg: *mut c_void)
-                     -> c_int;
+    pub fn onig_scan(
+        reg: OnigRegex,
+        str: *const OnigUChar,
+        end: *const OnigUChar,
+        region: *mut OnigRegion,
+        options: OnigOptionType,
+        scan_callback: OnigScanCallback,
+        callback_arg: *mut c_void,
+    ) -> c_int;
 
     ///   Create a region.
     ///
@@ -812,11 +814,12 @@ extern "C" {
     ///   2 name:      group name.
     ///   3 name_end:  terminate address of group name.
     ///   4 num_list:  return list of group number.
-    pub fn onig_name_to_group_numbers(reg: OnigRegex,
-                                      name: *const OnigUChar,
-                                      name_end: *const OnigUChar,
-                                      num_list: *mut *const c_int)
-                                      -> c_int;
+    pub fn onig_name_to_group_numbers(
+        reg: OnigRegex,
+        name: *const OnigUChar,
+        name_end: *const OnigUChar,
+        num_list: *mut *const c_int,
+    ) -> c_int;
 
     ///   Return the group number corresponding to the named backref (\k<name>).
     ///   If two or more regions for the groups of the name are effective,
@@ -832,11 +835,12 @@ extern "C" {
     ///   2 name:     group name.
     ///   3 name_end: terminate address of group name.
     ///   4 region:   search/match result region.
-    pub fn onig_name_to_backref_number(reg: OnigRegex,
-                                       name: *const OnigUChar,
-                                       name_end: *const OnigUChar,
-                                       region: *const OnigRegion)
-                                       -> c_int;
+    pub fn onig_name_to_backref_number(
+        reg: OnigRegex,
+        name: *const OnigUChar,
+        name_end: *const OnigUChar,
+        region: *const OnigRegion,
+    ) -> c_int;
 
     ///   Iterate function call for all names.
     ///
@@ -853,19 +857,20 @@ extern "C" {
     ///
     ///   1. reg:     regex object.
     ///   2. func:    callback function.
-    ///   
+    ///
     ///   ```c
     ///   func(name, name_end, <number of groups>, <group number's list>,
     ///        reg, arg);
     ///   ```
-    ///   
+    ///
     ///   if func does not return 0, then iteration is stopped.
     ///
     ///   3. arg:     argument for func.
-    pub fn onig_foreach_name(reg: OnigRegex,
-                             func: OnigForeachNameCallback,
-                             arg: *const c_void)
-                             -> c_int;
+    pub fn onig_foreach_name(
+        reg: OnigRegex,
+        func: OnigForeachNameCallback,
+        arg: *const c_void,
+    ) -> c_int;
 
     ///   Return the number of names defined in the pattern.
     ///   Multiple definitions of one name is counted as one.
@@ -959,12 +964,12 @@ extern "C" {
     ///      *  arg:   optional callback argument
     ///
     ///   4. arg;     optional callback argument.
-    pub fn onig_capture_tree_traverse(region: *const OnigRegion,
-                                      at: c_int,
-                                      func: OnigCaptureTreeTraverseCallback,
-                                      arg: *mut c_void)
-                                      -> c_int;
-
+    pub fn onig_capture_tree_traverse(
+        region: *const OnigRegion,
+        at: c_int,
+        func: OnigCaptureTreeTraverseCallback,
+        arg: *mut c_void,
+    ) -> c_int;
 
     ///   Return noname group capture activity.
     ///
@@ -1068,10 +1073,11 @@ extern "C" {
     /// ```
     ///
     /// 3. code: meta character or `ONIG_INEFFECTIVE_META_CHAR`.
-    pub fn onig_set_meta_char(syntax: *mut OnigSyntaxType,
-                              what: c_uint,
-                              code: OnigCodePoint)
-                              -> c_int;
+    pub fn onig_set_meta_char(
+        syntax: *mut OnigSyntaxType,
+        what: c_uint,
+        code: OnigCodePoint,
+    ) -> c_int;
 
     ///   Get default case fold flag.
     ///
@@ -1105,9 +1111,10 @@ extern "C" {
     /// int onig_unicode_define_user_property(const char* name,
     ///                                       OnigCodePoint* ranges);
     /// ```
-    pub fn onig_unicode_define_user_property(name: *const c_char,
-                                             ranges: *const OnigCodePoint)
-                                             -> c_int;
+    pub fn onig_unicode_define_user_property(
+        name: *const c_char,
+        ranges: *const OnigCodePoint,
+    ) -> c_int;
 
     /// Se the maximum number of captures
     ///

--- a/onig_sys/src/lib.rs
+++ b/onig_sys/src/lib.rs
@@ -1,4 +1,3 @@
-
 extern crate libc;
 
 mod constants;
@@ -227,6 +226,18 @@ pub struct OnigRegexType {
     pub dmax: OnigDistance, // max-distance of exact or map
 
     pub chain: *const OnigRegexType,
+}
+
+/// Match Parameters Struct
+///
+/// This can be passed to `onig_search_with_param` and
+/// `onig_match_with_param` to control their behavior. Instances can
+/// be created with `onig_new_match_param`. The contents of the struct
+/// should not be modified directly.
+#[repr(C)]
+pub struct OnigMatchParam {
+    /// External Data
+    _external: c_int
 }
 
 extern "C" {
@@ -519,6 +530,26 @@ extern "C" {
     ///   arguments
     ///   1 reg: regex object.
     pub fn onig_free_body(reg: OnigRegexMut);
+
+
+    /// Allocate a OnigMatchParam object and initialize the contents by
+    /// onig_initialize_match_param().
+    pub fn onig_new_match_param() -> *mut OnigMatchParam;
+
+    /// Free memory used by a OnigMatchParam object.
+    ///
+    /// # Arguments
+    ///
+    /// 1 mp: OnigMatchParam object
+    pub fn onig_free_match_param(mp: *mut OnigMatchParam);
+
+    /// Set match-param fields to default values.
+    /// Match-param is used in onig_match_with_param() and onig_search_with_param().
+    ///
+    /// # Arguments
+    ///
+    /// 1 mp: match-param pointer
+    pub fn onig_initialize_match_param(mp: *mut OnigMatchParam);
 
     ///   Search string and return search result and matching region.
     ///

--- a/onig_sys/src/lib.rs
+++ b/onig_sys/src/lib.rs
@@ -562,6 +562,16 @@ extern "C" {
     /// normal return: ONIG_NORMAL
     pub fn onig_set_match_stack_limit_size_of_match_param(mp: *mut OnigMatchParam, limit: c_uint) -> c_int;
 
+    /// Set a retry limit count of a match process.
+    ///
+    /// # Arguments
+    ///
+    /// 1 mp: match-param pointer
+    /// 2 limit: number of limit
+    ///
+    /// normal return: ONIG_NORMAL
+    pub fn onig_set_retry_limit_in_match_of_match_param(mp: *mut OnigMatchParam, limit: c_uint) -> c_int;
+
     ///   Search string and return search result and matching region.
     ///
     ///   `int onig_search(regex_t* reg, const UChar* str, const UChar* end, const UChar* start,

--- a/onig_sys/src/lib.rs
+++ b/onig_sys/src/lib.rs
@@ -606,6 +606,31 @@ extern "C" {
                        option: OnigOptionType)
                        -> c_int;
 
+    ///   Search string and return search result and matching region.
+    ///
+    ///   `int onig_search_with_param(regex_t* reg, const UChar* str, const UChar* end,
+    ///                               const UChar* start, const UChar* range, OnigRegion* region,
+    ///                               OnigOptionType option, OnigMatchParam* mp)`
+    ///
+    /// # Returns
+    ///
+    ///   normal return: match position offset (i.e.  p - str >= 0)
+    ///   not found:     ONIG_MISMATCH (< 0)
+    ///
+    /// # Arguments
+    ///
+    ///   1-7:  same as onig_search()
+    ///   8. `mp`: match parameters
+    pub fn onig_search_with_param(reg: OnigRegex,
+                                  str: *const OnigUChar,
+                                  end: *const OnigUChar,
+                                  start: *const OnigUChar,
+                                  range: *const OnigUChar,
+                                  region: *mut OnigRegion,
+                                  option: OnigOptionType,
+                                  mp: *const OnigMatchParam)
+                                  -> c_int;
+
     ///   Match string and return result and matching region.
     ///
     ///   `int onig_match(regex_t* reg, const UChar* str, const UChar* end, const UChar* at,
@@ -634,6 +659,30 @@ extern "C" {
                       at: *const OnigUChar,
                       region: *mut OnigRegion,
                       option: OnigOptionType)
+                      -> c_int;
+
+    ///   Match string and return result and matching region.
+    ///
+    ///   `int onig_match_with_param(regex_t* reg, const UChar* str, const UChar* end,
+    ///                              const UChar* at, OnigRegion* region,
+    ///                              OnigOptionType option, OnigMatchParam* mp)`
+    ///
+    /// # Returns
+    ///
+    ///   normal return: match length  (>= 0)
+    ///   not match:     ONIG_MISMATCH ( < 0)
+    ///
+    /// # Arguments
+    ///
+    ///   1-6:  same as onig_match()
+    ///   7. `mp`: match parameters
+    pub fn onig_match_with_param(reg: OnigRegex,
+                      str: *const OnigUChar,
+                      end: *const OnigUChar,
+                      at: *const OnigUChar,
+                      region: *mut OnigRegion,
+                      option: OnigOptionType,
+                      mp: *const OnigMatchParam)
                       -> c_int;
 
     ///   Scan string and callback with matching region.

--- a/onig_sys/src/lib.rs
+++ b/onig_sys/src/lib.rs
@@ -58,18 +58,18 @@ pub type OnigForeachNameCallback = extern "C" fn(*const OnigUChar,
 /// being traversed. See
 /// [`onig_capture_tree_traverse`](fn.onig_capture_tree_traverse.html)
 /// for more information about parameters and use.
-pub type OnigCaptureTreeTraverseCallback = extern "C" fn(c_int,
-                                                         c_int,
-                                                         c_int,
-                                                         c_int,
-                                                         c_int,
-                                                         *mut c_void)
-                                                         -> c_int;
+pub type OnigCaptureTreeTraverseCallback =
+    extern "C" fn(c_int, c_int, c_int, c_int, c_int, *mut c_void) -> c_int;
 
 /// ```c
 /// int (*scan_callback)(int, int, OnigRegion*, void*)
 /// ```
 pub type OnigScanCallback = extern "C" fn(c_int, c_int, *const OnigRegion, *mut c_void) -> c_int;
+
+/// ```c
+/// typedef int (*OnigCalloutFunc)(OnigCalloutArgs* args, void* user_data);
+/// ```
+pub type OnigCalloutFunc = extern "C" fn (args: *const OnigCalloutArgs, user_data: *const c_void) -> c_int;
 
 #[repr(C)]
 #[derive(Debug, Eq, PartialEq)]
@@ -237,7 +237,17 @@ pub struct OnigRegexType {
 #[repr(C)]
 pub struct OnigMatchParam {
     /// External Data
-    _external: c_int
+    _external: c_int,
+}
+
+/// Callout Args Struct
+///
+/// This is still an experimental API at the moment. The type is
+/// opaque to library users for now.
+#[repr(C)]
+pub struct OnigCalloutArgs {
+    /// External data
+    _external: c_int,
 }
 
 extern "C" {
@@ -570,7 +580,36 @@ extern "C" {
     /// 2 limit: number of limit
     ///
     /// normal return: ONIG_NORMAL
-    pub fn onig_set_retry_limit_in_match_of_match_param(mp: *mut OnigMatchParam, limit: c_uint) -> c_int;
+    pub fn onig_set_retry_limit_in_match_of_match_param(
+        mp: *mut OnigMatchParam,
+        limit: c_uint,
+    ) -> c_int;
+
+    ///  Set a function for callouts of contents in progress.
+    ///  If 0 (NULL) is set, never called in progress.
+    ///
+    ///  arguments
+    ///  1 mp: match-param pointer
+    ///  2 f: function
+    ///
+    ///  normal return: ONIG_NORMAL
+    pub fn onig_set_progress_callout_of_match_param(
+        mp: *mut OnigMatchParam,
+        f: OnigCalloutFunc,
+    ) -> c_int;
+
+    ///  Set a function for callouts of contents in retraction (backtrack).
+    ///  If 0 (NULL) is set, never called in retraction.
+    ///
+    ///  arguments
+    ///  1 mp: match-param pointer
+    ///  2 f: function
+    ///
+    ///  normal return: ONIG_NORMAL
+    pub fn onig_set_retraction_callout_of_match_param(
+        mp: *mut OnigMatchParam,
+        f: OnigCalloutFunc,
+    ) -> c_int;
 
     ///   Search string and return search result and matching region.
     ///

--- a/onig_sys/src/lib.rs
+++ b/onig_sys/src/lib.rs
@@ -551,6 +551,17 @@ extern "C" {
     /// 1 mp: match-param pointer
     pub fn onig_initialize_match_param(mp: *mut OnigMatchParam);
 
+    /// Set a maximum number of match-stack depth.
+    /// 0 means unlimited.
+    ///
+    /// # Arguments
+    ///
+    /// 1 mp: match-param pointer
+    /// 2 limit: number of limit
+    ///
+    /// normal return: ONIG_NORMAL
+    pub fn onig_set_match_stack_limit_size_of_match_param(mp: *mut OnigMatchParam, limit: c_uint) -> c_int;
+
     ///   Search string and return search result and matching region.
     ///
     ///   `int onig_search(regex_t* reg, const UChar* str, const UChar* end, const UChar* start,

--- a/onig_sys/src/onigenc.rs
+++ b/onig_sys/src/onigenc.rs
@@ -30,11 +30,12 @@ extern "C" {
     ///                               const OnigUChar* s,
     ///                               int n);
     /// ```
-    pub fn onigenc_step_back(enc: OnigEncoding,
-                             start: *const OnigUChar,
-                             s: *const OnigUChar,
-                             n: c_int)
-                             -> *const OnigUChar;
+    pub fn onigenc_step_back(
+        enc: OnigEncoding,
+        start: *const OnigUChar,
+        s: *const OnigUChar,
+        n: c_int,
+    ) -> *const OnigUChar;
 
     /// Onigenc Set Default Encoding
     ///
@@ -65,11 +66,12 @@ extern "C" {
     ///     const OnigUChar* start,
     ///     const OnigUChar* s,
     ///     const OnigUChar** prev);
-    pub fn onigenc_get_right_adjust_char_head_with_prev(enc: OnigEncoding,
-                                                        start: *const OnigUChar,
-                                                        s: *const OnigUChar,
-                                                        prev: *mut *const OnigUChar)
-                                                        -> *const OnigUChar;
+    pub fn onigenc_get_right_adjust_char_head_with_prev(
+        enc: OnigEncoding,
+        start: *const OnigUChar,
+        s: *const OnigUChar,
+        prev: *mut *const OnigUChar,
+    ) -> *const OnigUChar;
 
     ///   Return previous character head address.
     ///
@@ -79,10 +81,11 @@ extern "C" {
     ///   1 enc:   character encoding
     ///   2 start: string address
     ///   3 s:     target address of string
-    pub fn onigenc_get_prev_char_head(enc: OnigEncoding,
-                                      start: *const OnigUChar,
-                                      s: *const OnigUChar)
-                                      -> *const OnigUChar;
+    pub fn onigenc_get_prev_char_head(
+        enc: OnigEncoding,
+        start: *const OnigUChar,
+        s: *const OnigUChar,
+    ) -> *const OnigUChar;
 
     ///   Return left-adjusted head address of a character.
     ///
@@ -94,10 +97,11 @@ extern "C" {
     ///   1. enc:   character encoding
     ///   2. start: string address
     ///   3. s:     target address of string
-    pub fn onigenc_get_left_adjust_char_head(enc: OnigEncoding,
-                                             start: *const OnigUChar,
-                                             s: *const OnigUChar)
-                                             -> *const OnigUChar;
+    pub fn onigenc_get_left_adjust_char_head(
+        enc: OnigEncoding,
+        start: *const OnigUChar,
+        s: *const OnigUChar,
+    ) -> *const OnigUChar;
 
     ///   Return right-adjusted head address of a character.
     ///
@@ -109,10 +113,11 @@ extern "C" {
     ///   1. enc:   character encoding
     ///   2. start: string address
     ///   3. s:     target address of string
-    pub fn onigenc_get_right_adjust_char_head(enc: OnigEncoding,
-                                              start: *const OnigUChar,
-                                              s: *const OnigUChar)
-                                              -> *const OnigUChar;
+    pub fn onigenc_get_right_adjust_char_head(
+        enc: OnigEncoding,
+        start: *const OnigUChar,
+        s: *const OnigUChar,
+    ) -> *const OnigUChar;
 
     ///   Return number of characters in the string.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ mod find;
 mod flags;
 mod region;
 mod replace;
+mod match_param;
 mod names;
 mod syntax;
 mod tree;

--- a/src/match_param.rs
+++ b/src/match_param.rs
@@ -4,10 +4,23 @@
 //! used to control the behavior of searching and matcing.
 
 use onig_sys;
+use libc::c_uint;
 
 /// Parameters for a Match or Search.
 pub struct MatchParam {
     raw: *mut onig_sys::OnigMatchParam,
+}
+
+impl MatchParam {
+    /// Set the match statck limit
+    pub fn set_match_stack_limit(&mut self, limit: u32) {
+        unsafe {
+            onig_sys::onig_set_match_stack_limit_size_of_match_param(
+                self.raw,
+                limit as c_uint
+            );
+        }
+    }
 }
 
 impl Default for MatchParam {
@@ -37,5 +50,11 @@ mod test {
     #[test]
     pub fn create_default_match_param() {
         let _mp = MatchParam::default();
+    }
+
+    #[test]
+    pub fn set_max_stack_size_limit() {
+        let mut mp = MatchParam::default();
+        mp.set_match_stack_limit(1000);
     }
 }

--- a/src/match_param.rs
+++ b/src/match_param.rs
@@ -1,7 +1,7 @@
 //! Match Parameters
 //!
 //! Contains the definition for the `MatchParam` struct. This can be
-//! used to control the behavior of searching and matcing.
+//! used to control the behavior of searching and matching.
 
 use onig_sys;
 use libc::c_uint;

--- a/src/match_param.rs
+++ b/src/match_param.rs
@@ -1,0 +1,41 @@
+//! Match Parameters
+//!
+//! Contains the definition for the `MatchParam` struct. This can be
+//! used to control the behavior of searching and matcing.
+
+use onig_sys;
+
+/// Parameters for a Match or Search.
+pub struct MatchParam {
+    raw: *mut onig_sys::OnigMatchParam,
+}
+
+impl Default for MatchParam {
+    fn default() -> Self {
+        let raw = unsafe {
+            let new = onig_sys::onig_new_match_param();
+            onig_sys::onig_initialize_match_param(new);
+            new
+        };
+        MatchParam { raw }
+    }
+}
+
+impl Drop for MatchParam {
+    fn drop(&mut self) {
+        unsafe {
+            onig_sys::onig_free_match_param(self.raw);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    pub fn create_default_match_param() {
+        let _mp = MatchParam::default();
+    }
+}

--- a/src/match_param.rs
+++ b/src/match_param.rs
@@ -12,10 +12,20 @@ pub struct MatchParam {
 }
 
 impl MatchParam {
-    /// Set the match statck limit
+    /// Set the match stack limit
     pub fn set_match_stack_limit(&mut self, limit: u32) {
         unsafe {
             onig_sys::onig_set_match_stack_limit_size_of_match_param(
+                self.raw,
+                limit as c_uint
+            );
+        }
+    }
+
+    /// Set the retry limit in match
+    pub fn set_retry_limit_in_match(&mut self, limit: u32) {
+        unsafe {
+            onig_sys::onig_set_retry_limit_in_match_of_match_param(
                 self.raw,
                 limit as c_uint
             );
@@ -56,5 +66,11 @@ mod test {
     pub fn set_max_stack_size_limit() {
         let mut mp = MatchParam::default();
         mp.set_match_stack_limit(1000);
+    }
+
+    #[test]
+    pub fn set_retry_limit_in_match() {
+        let mut mp = MatchParam::default();
+        mp.set_retry_limit_in_match(1000);
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -15,7 +15,6 @@ pub struct CaptureTreeNode {
 }
 
 impl CaptureTreeNode {
-
     /// The capture group number for this capture
     pub fn group(&self) -> usize {
         self.raw.group as usize

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -51,7 +51,7 @@ mod tests {
     #[test]
     pub fn utils_get_version_returns_expected_version() {
         let version = version();
-        assert_eq!(version, "6.7.1");
+        assert_eq!(version, "6.8.0");
     }
 
     #[test]


### PR DESCRIPTION
Updates to support the full 6.8 Oniguruma API.

Oniguruma 6.8.0 adds new API surface for passing parameters into the search and match functions. This PR exposes the parameters object in both the `onig_sys` and `onig` crates & adds support for setting some of those match parameters.

Not sure what other more ergonomic APIs we might choose to expose built on top of these yet.

Fixes #75 