### PR TITLE
Add `match_with_param` and `search_with_param` to `Regex`

### DIFF
--- a/onig_sys/src/lib.rs
+++ b/onig_sys/src/lib.rs
@@ -596,6 +596,31 @@ extern "C" {
                        option: OnigOptionType)
                        -> c_int;
 
+    ///   Search string and return search result and matching region.
+    ///
+    ///   `int onig_search_with_param(regex_t* reg, const UChar* str, const UChar* end,
+    ///                               const UChar* start, const UChar* range, OnigRegion* region,
+    ///                               OnigOptionType option, OnigMatchParam* mp)`
+    ///
+    /// # Returns
+    ///
+    ///   normal return: match position offset (i.e.  p - str >= 0)
+    ///   not found:     ONIG_MISMATCH (< 0)
+    ///
+    /// # Arguments
+    ///
+    ///   1-7:  same as onig_search()
+    ///   8. `mp`: match parameters
+    pub fn onig_search_with_param(reg: OnigRegex,
+                                  str: *const OnigUChar,
+                                  end: *const OnigUChar,
+                                  start: *const OnigUChar,
+                                  range: *const OnigUChar,
+                                  region: *mut OnigRegion,
+                                  option: OnigOptionType,
+                                  mp: *const OnigMatchParam)
+                                  -> c_int;
+
     ///   Match string and return result and matching region.
     ///
     ///   `int onig_match(regex_t* reg, const UChar* str, const UChar* end, const UChar* at,
@@ -624,6 +649,30 @@ extern "C" {
                       at: *const OnigUChar,
                       region: *mut OnigRegion,
                       option: OnigOptionType)
+                      -> c_int;
+
+    ///   Match string and return result and matching region.
+    ///
+    ///   `int onig_match_with_param(regex_t* reg, const UChar* str, const UChar* end,
+    ///                              const UChar* at, OnigRegion* region,
+    ///                              OnigOptionType option, OnigMatchParam* mp)`
+    ///
+    /// # Returns
+    ///
+    ///   normal return: match length  (>= 0)
+    ///   not match:     ONIG_MISMATCH ( < 0)
+    ///
+    /// # Arguments
+    ///
+    ///   1-6:  same as onig_match()
+    ///   7. `mp`: match parameters
+    pub fn onig_match_with_param(reg: OnigRegex,
+                      str: *const OnigUChar,
+                      end: *const OnigUChar,
+                      at: *const OnigUChar,
+                      region: *mut OnigRegion,
+                      option: OnigOptionType,
+                      mp: *const OnigMatchParam)
                       -> c_int;
 
     ///   Scan string and callback with matching region.

--- a/src/match_param.rs
+++ b/src/match_param.rs
@@ -1,7 +1,7 @@
 //! Match Parameters
 //!
 //! Contains the definition for the `MatchParam` struct. This can be
-//! used to control the behavior of searching and matcing.
+//! used to control the behavior of searching and matching.
 
 use onig_sys;
 use libc::c_uint;


### PR DESCRIPTION
They use the new `onig_match_with_param` and `onig_search_with_param` in
Oniguruma.

Note that `onig_match` in Oniguruma delegates to
`onig_match_with_param`, so we can do the same for `Regex`.

Part of #75. (Based on #78, otherwise they would have conflicted.)