### PR TITLE
Avoid cmake dependency, workaround for crash in libgit2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -98,6 +98,8 @@ environment:
 matrix:
   allow_failures:
     - channel: nightly
+    - target: x86_64-pc-windows-gnu # rust-lang/rust#47048
+    - target: i686-pc-windows-gnu
 
 # If you only care about stable channel build failures, uncomment the following line:
     #- channel: beta

--- a/onig_sys/Cargo.toml
+++ b/onig_sys/Cargo.toml
@@ -22,13 +22,11 @@ libc = "0.2"
 
 [build-dependencies]
 pkg-config = "0.3"
-
-[target.'cfg(target_env="msvc")'.build-dependencies.duct]
-version = "0.10"
-
-[target.'cfg(not(target_env="msvc"))'.build-dependencies.cmake]
-version = "0.1"
+cc = "1.0.18"
 
 [features]
+default = ["posix-api"]
 # Make Oniguruma print debug output for parsing/compiling and executing
 print-debug = []
+# include regexec(), which conflicts with libgit2
+posix-api = []

--- a/onig_sys/src/lib.rs
+++ b/onig_sys/src/lib.rs
@@ -959,8 +959,8 @@ extern "C" {
     ///      *  end:   capture end position
     ///      *  level: nest level (from 0)
     ///      *  at:    callback position
-    ///          *     ONIG_TRAVERSE_CALLBACK_AT_FIRST
-    ///          *     ONIG_TRAVERSE_CALLBACK_AT_LAST
+    ///          * `ONIG_TRAVERSE_CALLBACK_AT_FIRST`
+    ///          * `ONIG_TRAVERSE_CALLBACK_AT_LAST`
     ///      *  arg:   optional callback argument
     ///
     ///   4. arg;     optional callback argument.


### PR DESCRIPTION
Replaces `cmake` with `cc`, because [cmake is frustrating for some](https://users.rust-lang.org/t/cmake-as-a-common-external-dependency-for-rust-crates/18701). Tested on macOS 10.14, Windows 10 (MSVC), and Debian 9.4.

I've also made it possible to disable POSIX API with a Cargo feature, because this API crashes libgit2.