### PR TITLE
Don't block CI on MSYS bug

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -98,6 +98,8 @@ environment:
 matrix:
   allow_failures:
     - channel: nightly
+    - target: x86_64-pc-windows-gnu # rust-lang/rust#47048
+    - target: i686-pc-windows-gnu
 
 # If you only care about stable channel build failures, uncomment the following line:
     #- channel: beta


### PR DESCRIPTION
It looks like -gnu targets won't work until this is fixed: 

https://github.com/rust-lang/rust/issues/47048

#82