### PR TITLE
Ability to disable posix-api from onig crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onig"
-version = "4.0.0"
+version = "4.0.1"
 authors = [
         "Will Speak <will@willspeak.me>",
         "Ivan Ivashchenko <defuz@me.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ readme = "README.md"
 license = "MIT"
 
 [features]
+default = ["posix-api"]
 std-pattern = []
+# include regexec()
+posix-api = ["onig_sys/posix-api"]
 # Make Oniguruma print debug output for parsing/compiling and executing
 print-debug = ["onig_sys/print-debug"]
 
@@ -26,3 +29,4 @@ lazy_static = "1.0"
 [dependencies.onig_sys]
 version = "68.0.1"
 path = "onig_sys"
+default-features = false


### PR DESCRIPTION
I forgot to expose the posix-api feature in the parent crate