### PR TITLE
Min versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 - linux
 
 rust:
+- 1.27.0
 - stable
 - beta
 - nightly
@@ -25,20 +26,6 @@ script:
     export LD_LIBRARY_PATH="${p}:${LD_LIBRARY_PATH}"
   fi
 - cargo test --features="$ONIG_FEATURES" --verbose
-- cargo doc --features="$ONIG_FEATURES" --verbose
-
-# Build the docs if we have had a successful master build
-after_success:
-- |
-  if [ "$TRAVIS_PULL_REQUEST" == "false" ] && \
-     [ "$TRAVIS_BRANCH" == "master" ] && \
-     [ "$TRAVIS_OS_NAME" == "linux" ] && \
-     [ "$TRAVIS_RUST_VERSION" == "stable" ]
-  then
-    git clone https://github.com/davisp/ghp-import
-    ./ghp-import/ghp-import -n target/doc
-    git push -fq https://$GH_TOKEN@github.com/rust-onig/rust-onig.git gh-pages
-  fi
 
 # Allow failures in the nightly build. We don't want to fail just
 # because of Rust instability.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-onig = "4.2"
+onig = "4.3"
 ```
 
 Add the following extern to your crate root:
@@ -80,9 +80,9 @@ The contents of this repository are distributed under the MIT license. See
 at our open [easy issues][easy_issues].
 
  [Onig_wiki]: https://en.wikipedia.org/wiki/Oniguruma
- [onig_crate_doc]: https://docs.rs/onig/4.2.0/onig/
+ [onig_crate_doc]: https://docs.rs/onig/4.3.2/onig/
  [examples_folder]: https://github.com/rust-onig/rust-onig/tree/master/onig/examples
- [regex_new]: https://docs.rs/onig/4.2.0/onig/struct.Regex.html#method.new
- [regex_is_match]: https://docs.rs/onig/4.2.0/onig/struct.Regex.html#method.is_match
- [regex_find]: https://docs.rs/onig/4.2.0/onig/struct.Regex.html#method.find
+ [regex_new]: https://docs.rs/onig/4.3.2/onig/struct.Regex.html#method.new
+ [regex_is_match]: https://docs.rs/onig/4.3.2/onig/struct.Regex.html#method.is_match
+ [regex_find]: https://docs.rs/onig/4.3.2/onig/struct.Regex.html#method.find
  [easy_issues]: https://github.com/rust-onig/rust-onig/issues?q=is%3Aopen+is%3Aissue+label%3AE-Easy

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ With all that combined, here's an example command to debug the pattern `a|b`:
 
     RUSTONIG_SYSTEM_LIBONIG=0 cargo run --features print-debug --example capturedump 'a|b'
 
+## Supported Rust Versions
+
+Rust onig supports Rust 1.27.0 or later. If the minimum supported rust
+version is changed then the minor version number will be
+increased. That is v4.2.x should always compile with the same version
+of the compiler.
+
 ## Rust-Onig is Open Source
 
 The contents of this repository are distributed under the MIT license. See

--- a/onig/Cargo.toml
+++ b/onig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onig"
-version = "4.3.1"
+version = "4.3.2"
 authors = [
     "Will Speak <will@willspeak.me>",
     "Ivan Ivashchenko <defuz@me.com>"

--- a/onig/src/find.rs
+++ b/onig/src/find.rs
@@ -177,7 +177,7 @@ impl Regex {
                 self.raw,
                 start,
                 end,
-                (&mut region.raw) as *mut onig_sys::OnigRegion,
+                (&mut region.raw) as *mut ::onig_sys::OnigRegion,
                 options.bits(),
                 scan_cb::<F>,
                 &mut callback as *mut F as *mut c_void,

--- a/onig/src/lib.rs
+++ b/onig/src/lib.rs
@@ -84,6 +84,7 @@
 //! features = ["std-pattern"]
 //! ```
 
+#![cfg_attr(not(feature = "cargo-clippy"), allow(unknown_lints))]
 #![cfg_attr(feature = "std-pattern", feature(pattern))]
 #![deny(missing_docs)]
 


### PR DESCRIPTION
Updates to the CI build, codebase, and documentation to explicity call out and test our minimum supported Rust version.