### PR TITLE
Disable bindgen features

### DIFF
--- a/onig_sys/Cargo.toml
+++ b/onig_sys/Cargo.toml
@@ -24,7 +24,7 @@ readme = "../README.md"
 license = "MIT"
 
 [build-dependencies]
-bindgen = "0.50"
+bindgen = { version="0.50", features=[] }
 pkg-config = "0.3"
 cc = "1.0"
 


### PR DESCRIPTION
bindgen is only used as library here, so its features (env_logger and clap, which are both only used with the binary) aren't useful to us.