### PR TITLE
Support building onig on wasm32-unknown-unknown target

### DIFF
--- a/onig_sys/Cargo.toml
+++ b/onig_sys/Cargo.toml
@@ -23,6 +23,9 @@ documentation = "http://rust-onig.github.io/rust-onig/onig_sys/"
 readme = "../README.md"
 license = "MIT"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [build-dependencies]
 bindgen = { version="0.50", features=[] }
 pkg-config = "0.3"

--- a/onig_sys/build.rs
+++ b/onig_sys/build.rs
@@ -83,18 +83,26 @@ fn compile() {
         );
     }
 
-    let os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    let bits = env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap();
-    if os == "windows" {
-        fs::copy(src.join(format!("config.h.win{}", bits)), config_h)
+    let arch = env::var("CARGO_CFG_TARGET_ARCH");
+    let os = env::var("CARGO_CFG_TARGET_OS");
+    let bits = env::var("CARGO_CFG_TARGET_POINTER_WIDTH");
+    if let Ok("windows") = os.as_ref().map(String::as_str) {
+        fs::copy(src.join(format!("config.h.win{}", bits.unwrap())), config_h)
             .expect("Can't copy config.h.win??");
     } else {
-        let family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
-        if family == "unix" {
+        if let Ok("unix") = env::var("CARGO_CFG_TARGET_FAMILY")
+            .as_ref()
+            .map(String::as_str)
+        {
             cc.define("HAVE_UNISTD_H", Some("1"));
             cc.define("HAVE_SYS_TYPES_H", Some("1"));
             cc.define("HAVE_SYS_TIME_H", Some("1"));
         }
+        let sizeof_long = if let Ok("64") = bits.as_ref().map(String::as_str) {
+            "8"
+        } else {
+            "4"
+        };
 
         // Can't use size_of::<c_long>(), because it'd refer to build arch, not target arch.
         // so instead assume it's a non-exotic target (LP32/LP64).
@@ -113,10 +121,17 @@ fn compile() {
             #define SIZEOF_SHORT 2
             #define SIZEOF_LONG {}
         ",
-                if bits == "64" { "8" } else { "4" }
+                sizeof_long
             ),
         )
         .expect("Can't write config.h to OUT_DIR");
+    }
+    if let Ok("wasm32") | Ok("wasm64") = arch.as_ref().map(String::as_str) {
+        cc.define("ONIG_DISABLE_DIRECT_THREADING", Some("1"));
+        cc.define(
+            "ONIG_EXTERN",
+            Some(r#"__attribute__((visibility("default")))"#),
+        );
     }
 
     cc.include(out_dir); // Read config.h from there
@@ -186,11 +201,12 @@ fn compile() {
 }
 
 fn bindgen_headers(path: &str) {
-    let bindings = bindgen::Builder::default()
-        .header(path)
-        .derive_eq(true)
-        .generate()
-        .expect("bindgen");
+    let arch = env::var("CARGO_CFG_TARGET_ARCH");
+    let mut bindgen = bindgen::Builder::default().header(path).derive_eq(true);
+    if let Ok("wasm32") | Ok("wasm64") = arch.as_ref().map(String::as_str) {
+        bindgen = bindgen.clang_arg(r#"-DONIG_EXTERN=__attribute__((visibility("default")))"#);
+    }
+    let bindings = bindgen.generate().expect("bindgen");
     let out_dir = env::var_os("OUT_DIR").expect("OUT_DIR");
     let out_path = Path::new(&out_dir);
     bindings
@@ -217,8 +233,8 @@ pub fn main() {
                         break;
                     }
                 }
-                return
-            },
+                return;
+            }
             Err(ref err) if require_pkg_config => {
                 panic!("Unable to find oniguruma in pkg-config, and RUSTONIG_SYSTEM_LIBONIG is set: {}", err);
             }


### PR DESCRIPTION
This PR adds support for the wasm32-unknown-unknown target to onig and onig_sys crates.

This currently does not produce a useful artifact due to https://github.com/rust-lang/rust/issues/63629, but it builds successfully when supplying C stdlib headers that support the target. For example, using the emscipten headers and clang-9:

```console
artichoke@a2ab9c0410ee:/app$ clang --version
clang version 9.0.0-svn366197-1~exp1+0~20190716095603.167~1.gbp7d3830 (trunk)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/local/bin
artichoke@a2ab9c0410ee:/app$ rustc --version --verbose
rustc 1.38.0-nightly (6e310f2ab 2019-07-07)
binary: rustc
commit-hash: 6e310f2abae97323ca1d5469657b83aa1a9407e0
commit-date: 2019-07-07
host: x86_64-unknown-linux-gnu
release: 1.38.0-nightly
LLVM version: 8.0
artichoke@a2ab9c0410ee:/app$ env CFLAGS="-I/app/libc" cargo build --target wasm32-unknown-unknown
warning: couldn't execute `llvm-config --prefix` (error: No such file or directory (os error 2))
warning: set the LLVM_CONFIG_PATH environment variable to a valid `llvm-config` executable
    Finished dev [unoptimized + debuginfo] target(s) in 3.22s
```

To achieve this goal, this PR pulls in a new version of oniguruma that has this PR https://github.com/kkos/oniguruma/pull/150 which introduces a macro to disable computed gotos which clang-8 cannot compile for wasm32-unknown-unknown.

This PR also refactors `build.rs` to be more robust to "non-exotic targets".