### PR TITLE
Update `pkg-config` Crate to Fix Missing CFLAGS

### DIFF
--- a/onig_sys/Cargo.toml
+++ b/onig_sys/Cargo.toml
@@ -25,7 +25,7 @@ license = "MIT"
 
 [build-dependencies]
 bindgen = { version="0.51", features=[] }
-pkg-config = "0.3"
+pkg-config = "^0.3.16"
 cc = "1.0"
 
 [features]


### PR DESCRIPTION
Some platforms require `pkgconfig` to be told to include system CFLAGS
otherwise we can't compile against the system copy of `onig`. This
updates the dependent crate to fix the issue.

Fixes: #119