### PR TITLE
onig_sys/build.rs: Error if oniguruma.h cannot be found

### DIFF
--- a/onig_sys/build.rs
+++ b/onig_sys/build.rs
@@ -210,14 +210,16 @@ pub fn main() {
         }
         match conf.probe("oniguruma") {
             Ok(lib) => {
-                for path in lib.include_paths {
+                for path in &lib.include_paths {
                     let header = path.join("oniguruma.h");
                     if header.exists() {
                         bindgen_headers(&header.display().to_string());
-                        break;
+                        return
                     }
                 }
-                return
+                if require_pkg_config {
+                    panic!("Unable to find oniguruma.h in include paths from pkg-config: {:?}", lib.include_paths);
+                }
             },
             Err(ref err) if require_pkg_config => {
                 panic!("Unable to find oniguruma in pkg-config, and RUSTONIG_SYSTEM_LIBONIG is set: {}", err);


### PR DESCRIPTION
It appears to be a logical error to end the build if oniguruma.h was not found and thus no bindings generated. This patch fixes it.