### PR TITLE
onig_sys/build.rs: Also search /usr/include for oniguruma.h, if we fail to find it via pkg-config

### DIFF
--- a/onig_sys/build.rs
+++ b/onig_sys/build.rs
@@ -217,8 +217,16 @@ pub fn main() {
                         return
                     }
                 }
+                let c_search_paths = [Path::new("/usr/include")];
+                for path in &c_search_paths {
+                    let header = path.join("oniguruma.h");
+                    if header.exists() {
+                        bindgen_headers(&header.display().to_string());
+                        return;
+                    }
+                }
                 if require_pkg_config {
-                    panic!("Unable to find oniguruma.h in include paths from pkg-config: {:?}", lib.include_paths);
+                    panic!("Unable to find oniguruma.h in /usr/include and include paths from pkg-config: {:?}", lib.include_paths);
                 }
             },
             Err(ref err) if require_pkg_config => {

--- a/onig_sys/build.rs
+++ b/onig_sys/build.rs
@@ -210,14 +210,16 @@ pub fn main() {
         }
         match conf.probe("oniguruma") {
             Ok(lib) => {
-                for path in lib.include_paths {
+                for path in &lib.include_paths {
                     let header = path.join("oniguruma.h");
                     if header.exists() {
                         bindgen_headers(&header.display().to_string());
-                        break;
+                        return
                     }
                 }
-                return
+                if require_pkg_config {
+                    panic!("Unable to find oniguruma.h in include paths from pkg-config: {:?}", lib.include_paths);
+                }
             },
             Err(ref err) if require_pkg_config => {
                 panic!("Unable to find oniguruma in pkg-config, and RUSTONIG_SYSTEM_LIBONIG is set: {}", err);


### PR DESCRIPTION
Under some conditions (pkg-config 0.3.15?) the pkg-config crate presents
us with an empty list of include directories.  This patch works around it.

The construction of `c_search_paths` is currently very crude. Please suggest an improvement that makes it more robust.

Depends on #124!