### PR TITLE
Update to bindgen-0.52, and disable default features

### DIFF
--- a/onig_sys/Cargo.toml
+++ b/onig_sys/Cargo.toml
@@ -24,7 +24,7 @@ readme = "../README.md"
 license = "MIT"
 
 [build-dependencies]
-bindgen = { version="0.51", features=[] }
+bindgen = { version="0.52", default-features=false }
 pkg-config = "^0.3.16"
 cc = "1.0"
 


### PR DESCRIPTION
Note that `features=[]` still leaves defaults enabled, but with just
`default-features=false` we truly build with no features at all.