### PR TITLE
Bump MSRV to 1.40.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ environment:
     FEATURES: ""
   matrix:
   # minimum version
-  - CHANNEL: 1.34.0
+  - CHANNEL: 1.40.0
     ARCH: i686
     ABI: msvc
   # "msvc" ABI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        rust: [1.34.0, stable, nightly]
+        rust: [1.40.0, stable, nightly]
 
     steps:
       - uses: hecrj/setup-rust-action@v1
@@ -86,7 +86,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        rust: [1.34.0, stable, nightly]
+        rust: [1.40.0, stable, nightly]
 
     steps:
       - uses: hecrj/setup-rust-action@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 - linux
 
 rust:
-- 1.34.0
+- 1.40.0
 - stable
 - beta
 - nightly

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ With all that combined, here's an example command to debug the pattern `a|b`:
 
 ## Supported Rust Versions
 
-Rust Onig supports Rust 1.34.0 or later for Windows, Linux, and
+Rust Onig supports Rust 1.40.0 or later for Windows, Linux, and
 macOS. If the minimum supported rust version is changed then the minor
-version number will be increased. That is v4.2.x should always compile
+version number will be increased. That is v6.1.x should always compile
 with the same version of the compiler.
 
 ## Rust-Onig is Open Source


### PR DESCRIPTION
Needed for the latest version of `clang-sys`. See
<https://github.com/rust-onig/rust-onig/pull/147#issuecomment-688958918>
for more information.