### PR TITLE
Remove Assertions from Match and Search

### DIFF
--- a/onig/src/lib.rs
+++ b/onig/src/lib.rs
@@ -170,7 +170,11 @@ impl Error {
     fn new(code: c_int, info: *const onig_sys::OnigErrorInfo) -> Self {
         let buff = &mut [0; onig_sys::ONIG_MAX_ERROR_MESSAGE_LEN as usize];
         let len = unsafe { onig_sys::onig_error_code_to_str(buff.as_mut_ptr(), code, info) };
-        let description = str::from_utf8(&buff[..len as usize]).unwrap();
+        let description = if let Ok(description) = str::from_utf8(&buff[..len as usize]) {
+            description
+        } else {
+            return Self::custom("Onig error string was invalid UTF-8");
+        };
         Error {
             data: ErrorData::OnigError(code),
             description: description.to_owned(),

--- a/onig/src/lib.rs
+++ b/onig/src/lib.rs
@@ -1016,6 +1016,21 @@ mod tests {
     }
 
     #[test]
+    fn test_search_with_invalid_range_panic() {
+        let regex = Regex::with_options("R...", RegexOptions::REGEX_OPTION_NONE, Syntax::default())
+            .expect("regex");
+        let string = "Ruby";
+        let is_match = panic::catch_unwind(|| regex.search_with_encoding(
+            string,
+            5,
+            string.len(),
+            SearchOptions::SEARCH_OPTION_NONE,
+            None,
+        ));
+        assert!(is_match.is_err());
+    }
+
+    #[test]
     fn test_match_with_invalid_range() {
         let regex = Regex::with_options("R...", RegexOptions::REGEX_OPTION_NONE, Syntax::default())
             .expect("regex");
@@ -1027,6 +1042,20 @@ mod tests {
             None,
             MatchParam::default(),
         );
+        assert!(is_match.is_err());
+    }
+
+    #[test]
+    fn test_match_with_invalid_range_panic() {
+        let regex = Regex::with_options("R...", RegexOptions::REGEX_OPTION_NONE, Syntax::default())
+            .expect("regex");
+        let string = "Ruby";
+        let is_match = panic::catch_unwind(|| regex.match_with_encoding(
+            string,
+            5,
+            SearchOptions::SEARCH_OPTION_NONE,
+            None,
+        ));
         assert!(is_match.is_err());
     }
 }

--- a/onig/src/lib.rs
+++ b/onig/src/lib.rs
@@ -514,7 +514,9 @@ impl Regex {
     where
         T: EncodedChars,
     {
-        assert_eq!(chars.encoding(), self.encoding());
+        if chars.encoding() != self.encoding() {
+            return Err(Error::custom(format!("Regex encoding does not match haystack encoding ({0:?}, {1:?})", chars.encoding(), self.encoding())));
+        }
         let r = unsafe {
             let offset = chars.start_ptr().add(at);
             if offset > chars.limit_ptr() {
@@ -643,7 +645,7 @@ impl Regex {
 
         match result {
             Ok(r) => r,
-            Err(e) => panic!("Onig: Regex search error: {}", e.description),
+            Err(e) => panic!("Onig: Regex search error: {}", e.description()),
         }
     }
 
@@ -702,7 +704,9 @@ impl Regex {
         T: EncodedChars,
     {
         let (beg, end) = (chars.start_ptr(), chars.limit_ptr());
-        assert_eq!(self.encoding(), chars.encoding());
+        if chars.encoding() != self.encoding() {
+            return Err(Error::custom(format!("Regex encoding does not match haystack encoding ({0:?}, {1:?})", chars.encoding(), self.encoding())));
+        }
         let r = unsafe {
             let start = beg.add(from);
             let range = beg.add(to);


### PR DESCRIPTION
This means that callers who expect a `Result` value can gracefully
hadle out of bounds errors.

Fixes:  #102