### PR TITLE
Ensure no UB, using `#[repr(transparent)]`

### DIFF
--- a/onig/src/region.rs
+++ b/onig/src/region.rs
@@ -10,6 +10,7 @@ use super::CaptureTreeNode;
 
 /// Represents a set of capture groups found in a search or match.
 #[derive(Debug, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Region {
     pub(crate) raw: onig_sys::OnigRegion,
 }

--- a/onig/src/syntax.rs
+++ b/onig/src/syntax.rs
@@ -28,6 +28,7 @@ pub enum MetaChar {
 /// For a demonstration of creating a custom syntax see
 /// `examples/syntax.rs` in the main onig crate.
 #[derive(Debug, Clone, Copy)]
+#[repr(transparent)]
 pub struct Syntax {
     raw: onig_sys::OnigSyntaxType,
 }

--- a/onig/src/tree.rs
+++ b/onig/src/tree.rs
@@ -10,8 +10,8 @@ use std::ops::Index;
 /// Represents a single node in the capture tree. Can be queried for
 /// information about the given capture and any child-captures that
 /// took place.
-#[repr(C)]
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct CaptureTreeNode {
     raw: onig_sys::OnigCaptureTreeNode,
 }

--- a/onig/src/tree.rs
+++ b/onig/src/tree.rs
@@ -54,7 +54,7 @@ impl Index<usize> for CaptureTreeNode {
     }
 }
 
-/// Caputres iterator
+/// Captures iterator
 #[derive(Debug)]
 pub struct CaptureTreeNodeIter<'t> {
     idx: usize,


### PR DESCRIPTION
This fixes some places that might have been UB on a super-strict reading, but can't be any longer.  It changes nothing about the operation or behavior of the code—arguably it just encodes what the code should have been to begin with.

There's also a typo fix, in its own commit.