### PR TITLE
Fix for 32 bit segfaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 .vagrant/
 *.orig
 .idea/
+*.log

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,10 +2,11 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "ubuntu/xenial64"
-  config.vm.provision "shell", inline: <<-SHELL
+  # config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/xenial32"
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
     sudo apt-get update
-    sudo apt-get install -y clang make binutils cmake
-    curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- -y 2>/dev/null
+    sudo apt-get install -y clang-8 make binutils cmake
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y 2>/dev/null
   SHELL
 end

--- a/onig_sys/build.rs
+++ b/onig_sys/build.rs
@@ -113,7 +113,9 @@ fn compile() {
             #define HAVE_INTTYPES_H 1
             #define SIZEOF_INT 4
             #define SIZEOF_SHORT 2
-            #define SIZEOF_LONG {}
+            #define SIZEOF_LONG {0}
+            #define SIZEOF_VOIDP {0}
+            #define SIZEOF_LONG_LONG 8
         ",
                 if bits == "64" { "8" } else { "4" }
             ),


### PR DESCRIPTION
Our fabrication of the `config.h` file left a little to be desired. On 32 bit platforms
the `st.h` file was failing to use the correct integer types for holding data values.
this then ended up in garbage reads due to bad pointer->integer->pointer casts.

Fixes #155 