### PR TITLE
Bump bindgen to 0.56.0

### DIFF
--- a/onig_sys/Cargo.toml
+++ b/onig_sys/Cargo.toml
@@ -24,7 +24,7 @@ readme = "../README.md"
 license = "MIT"
 
 [build-dependencies]
-bindgen = { version = "0.55", optional = true, features = [ "runtime" ] }
+bindgen = { version = "0.56", optional = true, features = [ "runtime" ] }
 pkg-config = "^0.3.16"
 cc = "1.0"
 


### PR DESCRIPTION
The version bump does not require any other changes, as usual for bindgen updates. A local build succeeded without issues.