### PR TITLE
Feature/flags

### DIFF
--- a/onig/src/flags.rs
+++ b/onig/src/flags.rs
@@ -69,6 +69,9 @@ bitflags! {
         /// `?`
         const SYNTAX_OPERATOR_QMARK_ZERO_ONE
             = (onig_sys::ONIG_SYN_OP_QMARK_ZERO_ONE as u64);
+	/// ?P
+	const SYNTAX_OPERATOR_QMARK_CAPITAL_P_NAME
+	    = (onig_sys::ONIG_SYN_OP2_QMARK_CAPITAL_P_NAME as u64);
         /// `{lower,upper}`
         const SYNTAX_OPERATOR_BRACE_INTERVAL
             = (onig_sys::ONIG_SYN_OP_BRACE_INTERVAL as u64);

--- a/onig/src/syntax.rs
+++ b/onig/src/syntax.rs
@@ -107,6 +107,38 @@ impl Syntax {
         }
     }
 
+    /// Get main syntax operators
+    pub fn get_syntax_op(&self) -> SyntaxOperator {
+	unsafe {
+            let op = onig_sys::onig_get_syntax_op(self.raw_mut());
+            SyntaxOperator::from_bits_truncate(u64::from(op))	
+	}
+    }
+
+    /// Set main syntax operators
+    pub fn set_syntax_op(&mut self, operators: SyntaxOperator) {
+	unsafe {
+	    let op = onig_sys::onig_get_syntax_op(self.raw_mut());
+	    onig_sys::onig_set_syntax_op(&mut self.raw, op + (operators.bits() as onig_sys::OnigSyntaxOp));
+	}
+    }
+
+    /// Get secondary syntax operators
+    pub fn get_syntax_op2(&self) -> SyntaxOperator {
+	unsafe {
+            let op = onig_sys::onig_get_syntax_op2(self.raw_mut());
+            SyntaxOperator::from_bits_truncate(u64::from(op) << 32)
+	}
+    }
+
+    /// Set secondary syntax operators    
+    pub fn set_syntax_op2(&mut self, operators: SyntaxOperator) {
+	unsafe {
+	    let op = onig_sys::onig_get_syntax_op2(self.raw_mut());
+	    onig_sys::onig_set_syntax_op2(&mut self.raw, op + (operators.bits() as onig_sys::OnigSyntaxOp));
+	}
+    }
+    
     /// Replace the operators for this syntax
     pub fn set_operators(&mut self, operators: SyntaxOperator) {
         let op = operators.bits() as onig_sys::OnigSyntaxOp;


### PR DESCRIPTION
This PR deals with a bug I encountered when trying to set `SyntaxOperator::SYNTAX_OPERATOR_ESC_X_BRACE_HEX8`
with `python` syntax with the `set_operators` function.
What would happen is that `set_operators` would override the `op2` fields.
So I added functions to deal explicitly withe `op` and `op2`