### PR TITLE
Bump MSRV to 1.50.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ environment:
     FEATURES: ""
   matrix:
   # minimum version
-  - CHANNEL: 1.40.0
+  - CHANNEL: 1.50.0
     ARCH: i686
     ABI: msvc
   # "msvc" ABI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        rust: [1.40.0, stable, nightly]
+        rust: [1.50.0, stable, nightly]
 
     steps:
       - uses: hecrj/setup-rust-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        rust: [1.40.0, stable, nightly]
+        rust: [1.50.0, stable, nightly]
 
     steps:
       - uses: hecrj/setup-rust-action@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 - linux
 
 rust:
-- 1.40.0
+- 1.50.0
 - stable
 - beta
 - nightly

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://crates.io/crates/onig)
 https://docs.rs/onig)
 ![CI](https://github.com/rust-onig/rust-onig/workflows/CI/badge.svg)
 [![Build status](https://ci.appveyor.com/api/projects/status/7qxdb44xpw4bkjfi/branch/main?svg=true)](https://ci.appveyor.com/project/iwillspeak/rust-onig/branch/main)
-[![dependency status](https://deps.rs/crate/onig/6.2.0/status.svg)](https://deps.rs/crate/onig/6.2.0)
+[![dependency status](https://deps.rs/crate/onig/6.3.0/status.svg)](https://deps.rs/crate/onig/6.3.0)
 
 Rust bindings for the [Oniguruma regex library][Onig_wiki], a powerful and mature regular expression library with support for a wide range of character sets and language syntaxes. Oniguruma is written in C. This repository provides two crates: `onig-sys` which provides the raw Rust FFI bindings, and `onig`, which provides a safe Rust wrapper around them.
 
@@ -82,9 +82,9 @@ With all that combined, here's an example command to debug the pattern `a|b`:
 
 ## Supported Rust Versions
 
-Rust Onig supports Rust 1.40.0 or later for Windows, Linux, and
+Rust Onig supports Rust 1.50.0 or later for Windows, Linux, and
 macOS. If the minimum supported rust version is changed then the minor
-version number will be increased. That is v6.1.x should always compile
+version number will be increased. That is v6.3.x should always compile
 with the same version of the compiler.
 
 ## Rust-Onig is Open Source
@@ -96,7 +96,7 @@ at our open [easy issues][easy_issues].
  [Onig_wiki]: https://en.wikipedia.org/wiki/Oniguruma
  [onig_crate_doc]: https://docs.rs/onig/
  [examples_folder]: https://github.com/rust-onig/rust-onig/tree/main/onig/examples
- [regex_new]: https://docs.rs/onig/6.2.0/onig/struct.Regex.html#method.new
- [regex_is_match]: https://docs.rs/onig/6.2.0/onig/struct.Regex.html#method.is_match
- [regex_find]: https://docs.rs/onig/6.2.0/onig/struct.Regex.html#method.find
+ [regex_new]: https://docs.rs/onig/6.3.0/onig/struct.Regex.html#method.new
+ [regex_is_match]: https://docs.rs/onig/6.3.0/onig/struct.Regex.html#method.is_match
+ [regex_find]: https://docs.rs/onig/6.3.0/onig/struct.Regex.html#method.find
  [easy_issues]: https://github.com/rust-onig/rust-onig/issues?q=is%3Aopen+is%3Aissue+label%3AE-Easy

--- a/onig/Cargo.toml
+++ b/onig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onig"
-version = "6.2.0"
+version = "6.3.0"
 authors = [
     "Will Speak <will@willspeak.me>",
     "Ivan Ivashchenko <defuz@me.com>"


### PR DESCRIPTION
Our MSRV hasn't been bumped in quite some time. We're now 15 versions
behind the current stable. Bump by 10 to try and get things building
again.