### PR TITLE
README: Correct typo of RUSTONIG_DYNAMIC_LIBONIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If a version of Oniguruma can be found by `pkg-config` then that will be used. I
 
 By default `rust-onig` will be statically linked to `libonig`. If you would rather that dynamic linking is used then the environment variables `RUSTONIG_STATIC_LIBONIG` and `RUSTONIG_DYNAMIC_LIBONIG` can be set. On *nix:
 
-    $ RUSTONIG_DYNAMIC_LIBONING=1 cargo build
+    $ RUSTONIG_DYNAMIC_LIBONIG=1 cargo build
 
 Or Windows:
 


### PR DESCRIPTION
This an extra n (LIBONING instead of LIBONIG) and caused a mistake when a copied and pasted it