### PR TITLE
onig_sys: Add cargo:rerun-if-env-changed flags

### DIFF
--- a/onig_sys/build.rs
+++ b/onig_sys/build.rs
@@ -37,7 +37,7 @@ impl fmt::Display for LinkType {
 }
 
 fn env_var_bool(name: &str) -> Option<bool> {
-    if !name.starts_with("CARGO") {
+    if name.starts_with("RUSTONIG") {
         println!("cargo:rerun-if-env-changed={}", name);
     }
     env::var(name)

--- a/onig_sys/build.rs
+++ b/onig_sys/build.rs
@@ -37,6 +37,9 @@ impl fmt::Display for LinkType {
 }
 
 fn env_var_bool(name: &str) -> Option<bool> {
+    if !name.starts_with("CARGO") {
+        println!("cargo:rerun-if-env-changed={}", name);
+    }
     env::var(name)
         .ok()
         .map(|s| match &s.to_string().to_lowercase()[..] {


### PR DESCRIPTION
This properly reruns the build if the value of $RUSTONIG_DYNAMIC_LIBONING
changes (and all the similar values)

See the cargo reference on build scripts ["change detection"](https://doc.rust-lang.org/cargo/reference/build-scripts.html#change-detection) for more details.

I have conirmed this works both on the latest stable and the MSRV (Rust 1.50)
