### PR TITLE
Replace `lazy_static` with `once_cell`

### DIFF
--- a/onig/Cargo.toml
+++ b/onig/Cargo.toml
@@ -29,7 +29,7 @@ generate = ["onig_sys/generate"]
 
 [dependencies]
 bitflags = "1.3"
-lazy_static = "1.4"
+once_cell = "1.12"
 
 [target.'cfg(windows)'.dependencies]
 libc = "0.2"

--- a/onig/src/lib.rs
+++ b/onig/src/lib.rs
@@ -90,11 +90,12 @@
 
 #[macro_use]
 extern crate bitflags;
-#[macro_use]
-extern crate lazy_static;
 #[cfg(windows)]
 extern crate libc;
+extern crate once_cell;
 extern crate onig_sys;
+
+use once_cell::sync::Lazy;
 
 mod buffers;
 mod find;
@@ -213,9 +214,7 @@ impl fmt::Debug for Error {
     }
 }
 
-lazy_static! {
-    static ref REGEX_NEW_MUTEX: Mutex<()> = Mutex::new(());
-}
+static REGEX_NEW_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
 impl Regex {
     /// Create a Regex


### PR DESCRIPTION
`onig` is the only dependency left in Artichoke's `Cargo.lock` that uses `lazy_static`. It looks like most of the ecosystem has moved to `once_cell`. `once_cell` looks to be more actively maintained and is IMO nicer to read since there are no macros. Additionally, I believe `once_cell` is a nightly Rust API so it is conceivable that once these types land in `std`, `once_cell` will simply re-export types from `std`.

See also this related change in `wasm-bindgen`:

- https://github.com/rustwasm/wasm-bindgen/pull/2962

`once_cell`'s MSRV is documented to be 1.36.0:

https://github.com/matklad/once_cell/blob/eda22cec55e9d37b16d408b7d0a5b396c7feb44c/CHANGELOG.md#151

As an aside, I noticed `onig` is using the 2015 edition. Do you have any interest in upgrading the code to 2018 edition? It's been a while since I've had to type `extern crate` 😅 