### PR TITLE
Bump the bindgen version

### DIFF
--- a/onig_sys/Cargo.toml
+++ b/onig_sys/Cargo.toml
@@ -25,7 +25,7 @@ readme = "../README.md"
 license = "MIT"
 
 [build-dependencies]
-bindgen = { version = "0.59", optional = true, features = [ "runtime" ] }
+bindgen = { version = "0.64", optional = true, features = [ "runtime" ] }
 pkg-config = "^0.3.16"
 cc = "1.0"
 


### PR DESCRIPTION
It solves a problem with modern clang generating invalid Idents for anonymous unions.

Fixes #173