### PR TITLE
Bump MSRV after Bindgen Update

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ environment:
     FEATURES: ""
   matrix:
   # minimum version
-  - CHANNEL: 1.50.0
+  - CHANNEL: 1.60.0
     ARCH: i686
     ABI: msvc
   # "msvc" ABI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        rust: [1.50.0, stable, nightly]
+        rust: [1.60.0, stable, nightly]
 
     steps:
       - uses: hecrj/setup-rust-action@v1
@@ -86,7 +86,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        rust: [1.50.0, stable, nightly]
+        rust: [1.60.0, stable, nightly]
 
     steps:
       - uses: hecrj/setup-rust-action@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 - linux
 
 rust:
-- 1.50.0
+- 1.60.0
 - stable
 - beta
 - nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file contains the "big hitters" for each release. For more detailed
 information about the exact changes in each release check the source code at
 <https://github.com/rust-onig/rust-onig>.
 
+## 6.5.0
+
+ * Bump Bindgen for Clang 16 support.
+ * Bump MSRV to 2021 (1.60.0)
+
 ## 6.4.0
 
  * Upgrade to Rust 2018, #170

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ With all that combined, here's an example command to debug the pattern `a|b`:
 
 ## Supported Rust Versions
 
-Rust Onig supports Rust 1.50.0 or later for Windows, Linux, and
+Rust Onig supports Rust 1.60.0 or later for Windows, Linux, and
 macOS. If the minimum supported rust version (MSRV) is changed then the minor
-version number will be increased. That is v6.4.x should always compile
+version number will be increased. That is v6.5.x should always compile
 with the same version of the compiler.
 
 ## Rust-Onig is Open Source

--- a/onig/Cargo.toml
+++ b/onig/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "onig"
-version = "6.4.0"
-edition = "2018"
+version = "6.5.0"
+edition = "2021"
 authors = [
     "Will Speak <will@willspeak.me>",
     "Ivan Ivashchenko <defuz@me.com>"

--- a/onig/src/lib.rs
+++ b/onig/src/lib.rs
@@ -756,7 +756,7 @@ impl Regex {
     ///
     /// `true` if the pattern matches the whole of `text`, `false` otherwise.
     pub fn is_match(&self, text: &str) -> bool {
-        self.match_with_options(text, 0, SearchOptions::SEARCH_OPTION_WHOLE_STRING, None)
+        self.match_with_options(text, 0, SearchOptions::SEARCH_OPTION_NONE, None)
             .map(|r| r == text.len())
             .unwrap_or(false)
     }
@@ -922,13 +922,6 @@ mod tests {
         let regex = Regex::new("he(l+)o").unwrap();
         assert!(regex.is_match("hello"));
         assert!(!regex.is_match("hello 2.0"));
-    }
-
-    #[test]
-    fn test_is_match_chooses_longest_alternation() {
-        let regex = Regex::new("Greater|GreaterOrEqual").unwrap();
-        assert!(regex.is_match("Greater"));
-        assert!(regex.is_match("GreaterOrEqual"));
     }
 
     #[test]

--- a/onig_sys/Cargo.toml
+++ b/onig_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onig_sys"
-version = "69.8.1"
+version = "69.8.2"
 edition = "2018"
 authors = [
     "Will Speak <will@willspeak.me>",


### PR DESCRIPTION
Bumping bindgen to support the latest Clang toolchains requires us to bump our supported edition from 2018 to 2021, and our supported rust version from 1.50.0 to 1.60.0 (Required by the `log` crate.