### PR TITLE
Upgrade to bitflags v2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ environment:
     FEATURES: ""
   matrix:
   # minimum version
-  - CHANNEL: 1.50.0
+  - CHANNEL: 1.60.0
     ARCH: i686
     ABI: msvc
   # "msvc" ABI

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ environment:
     FEATURES: ""
   matrix:
   # minimum version
-  - CHANNEL: 1.60.0
+  - CHANNEL: 1.63.0
     ARCH: i686
     ABI: msvc
   # "msvc" ABI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        rust: [1.60.0, stable, nightly]
+        rust: [1.63.0, stable, nightly]
 
     steps:
       - uses: hecrj/setup-rust-action@v1
@@ -86,7 +86,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        rust: [1.60.0, stable, nightly]
+        rust: [1.63.0, stable, nightly]
 
     steps:
       - uses: hecrj/setup-rust-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        rust: [1.50.0, stable, nightly]
+        rust: [1.56.0, stable, nightly]
 
     steps:
       - uses: hecrj/setup-rust-action@v1
@@ -86,7 +86,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        rust: [1.50.0, stable, nightly]
+        rust: [1.56.0, stable, nightly]
 
     steps:
       - uses: hecrj/setup-rust-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        rust: [1.56.0, stable, nightly]
+        rust: [1.60.0, stable, nightly]
 
     steps:
       - uses: hecrj/setup-rust-action@v1
@@ -86,7 +86,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        rust: [1.56.0, stable, nightly]
+        rust: [1.60.0, stable, nightly]
 
     steps:
       - uses: hecrj/setup-rust-action@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 - linux
 
 rust:
-- 1.50.0
+- 1.56.0
 - stable
 - beta
 - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 - linux
 
 rust:
-- 1.60.0
+- 1.63.0
 - stable
 - beta
 - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 - linux
 
 rust:
-- 1.56.0
+- 1.60.0
 - stable
 - beta
 - nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file contains the "big hitters" for each release. For more detailed
 information about the exact changes in each release check the source code at
 <https://github.com/rust-onig/rust-onig>.
 
+## 6.5.0
+
+ * Upgrade `bitflags` to at least v2.4.0
+ * MSRV bumped to 1.56.0
+
 ## 6.4.0
 
  * Upgrade to Rust 2018, #170

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ With all that combined, here's an example command to debug the pattern `a|b`:
 
 ## Supported Rust Versions
 
-Rust Onig supports Rust 1.60.0 or later for Windows, Linux, and
+Rust Onig supports Rust 1.63.0 or later for Windows, Linux, and
 macOS. If the minimum supported rust version (MSRV) is changed then the minor
 version number will be increased. That is v6.5.x should always compile
 with the same version of the compiler.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ With all that combined, here's an example command to debug the pattern `a|b`:
 
 ## Supported Rust Versions
 
-Rust Onig supports Rust 1.56.0 or later for Windows, Linux, and
+Rust Onig supports Rust 1.60.0 or later for Windows, Linux, and
 macOS. If the minimum supported rust version (MSRV) is changed then the minor
 version number will be increased. That is v6.5.x should always compile
 with the same version of the compiler.

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ With all that combined, here's an example command to debug the pattern `a|b`:
 
 ## Supported Rust Versions
 
-Rust Onig supports Rust 1.50.0 or later for Windows, Linux, and
+Rust Onig supports Rust 1.56.0 or later for Windows, Linux, and
 macOS. If the minimum supported rust version (MSRV) is changed then the minor
-version number will be increased. That is v6.4.x should always compile
+version number will be increased. That is v6.5.x should always compile
 with the same version of the compiler.
 
 ## Rust-Onig is Open Source

--- a/onig/Cargo.toml
+++ b/onig/Cargo.toml
@@ -2,6 +2,7 @@
 name = "onig"
 version = "6.5.0"
 edition = "2018"
+rust-version = "1.60.0"
 authors = [
     "Will Speak <will@willspeak.me>",
     "Ivan Ivashchenko <defuz@me.com>"

--- a/onig/Cargo.toml
+++ b/onig/Cargo.toml
@@ -2,7 +2,7 @@
 name = "onig"
 version = "6.5.0"
 edition = "2018"
-rust-version = "1.60.0"
+rust-version = "1.63.0"
 authors = [
     "Will Speak <will@willspeak.me>",
     "Ivan Ivashchenko <defuz@me.com>"

--- a/onig/Cargo.toml
+++ b/onig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onig"
-version = "6.4.0"
+version = "6.5.0"
 edition = "2018"
 authors = [
     "Will Speak <will@willspeak.me>",
@@ -29,7 +29,7 @@ print-debug = ["onig_sys/print-debug"]
 generate = ["onig_sys/generate"]
 
 [dependencies]
-bitflags = "1.3"
+bitflags = "2.4.0"
 once_cell = "1.12"
 
 [target.'cfg(windows)'.dependencies]

--- a/onig/src/flags.rs
+++ b/onig/src/flags.rs
@@ -3,6 +3,7 @@ use std::os::raw::c_uint;
 
 bitflags! {
     /// Regex parsing and compilation options.
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct RegexOptions: onig_sys::OnigOptionType {
         /// Default options.
         const REGEX_OPTION_NONE
@@ -41,6 +42,7 @@ bitflags! {
 
 bitflags! {
     /// Regex evaluation options.
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct SearchOptions: onig_sys::OnigOptionType {
         /// Default options.
         const SEARCH_OPTION_NONE
@@ -59,6 +61,7 @@ bitflags! {
 
 bitflags! {
     /// Defines the different operators allowed within a regex syntax.
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct SyntaxOperator: u64 {
         /// `.`
         const SYNTAX_OPERATOR_DOT_ANYCHAR
@@ -212,6 +215,7 @@ bitflags! {
 
 bitflags! {
     /// Defines the behaviour of regex operators.
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct SyntaxBehavior: onig_sys::OnigSyntaxBehavior {
         /// `?, *, +, {n,m}`
         const SYNTAX_BEHAVIOR_CONTEXT_INDEP_REPEAT_OPS
@@ -263,6 +267,7 @@ bitflags! {
 
 bitflags! {
     /// The order in which traverse callbacks are invoked
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct TraverseCallbackAt: c_uint {
         /// Callback before children are wallked
         const CALLBACK_AT_FIRST =
@@ -278,6 +283,7 @@ bitflags! {
 
 bitflags! {
     /// Syntax meta character types
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct MetaCharType: c_uint {
         /// The escape charater for this syntax
         const META_CHAR_ESCAPE = onig_sys::ONIG_META_CHAR_ESCAPE;

--- a/onig_sys/Cargo.toml
+++ b/onig_sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "onig_sys"
 version = "69.8.1"
 edition = "2018"
-rust-version = "1.60.0"
+rust-version = "1.63.0"
 authors = [
     "Will Speak <will@willspeak.me>",
     "Ivan Ivashchenko <defuz@me.com>"

--- a/onig_sys/Cargo.toml
+++ b/onig_sys/Cargo.toml
@@ -2,6 +2,7 @@
 name = "onig_sys"
 version = "69.8.1"
 edition = "2018"
+rust-version = "1.60.0"
 authors = [
     "Will Speak <will@willspeak.me>",
     "Ivan Ivashchenko <defuz@me.com>"


### PR DESCRIPTION
Prepare for v6.5.0 release.

As a compatibility note, bitflags v2 does not generate a `from_bits_unchecked` method. See the "major changes" section of the release notes: https://github.com/bitflags/bitflags/releases/tag/2.0.0

I consider this breakage to be minor and not worth a major version bump, but I'm happy to rev the `onig` crate to 7.0.0 if you'd prefer.

I'd appreciate getting this released. `onig` is one of the last crates in my lockfile that hasn't yet upgraded to `bitflags` v2.