### PR TITLE
Fix documentation link of `onig_sys` crate on crates.io is 404

### DIFF
--- a/onig_sys/Cargo.toml
+++ b/onig_sys/Cargo.toml
@@ -20,8 +20,8 @@ You probably don't want to link to this crate directly;
 instead check out the `onig` crate.
 """
 categories = ["external-ffi-bindings"]
-repository = "https://github.com/iwillspeak/rust-onig"
-documentation = "https://rust-onig.github.io/rust-onig/onig_sys/"
+repository = "https://github.com/rust-onig/rust-onig"
+documentation = "https://docs.rs/onig_sys"
 readme = "../README.md"
 license = "MIT"
 


### PR DESCRIPTION
I noticed that the documentation link in https://crates.io/crates/onig_sys was 404. This PR fixes it.