### PR TITLE
onig_sys(build.rs): Define HAVE_ALLOCA_H to avoid implicit declaration warnings for alloca.

### DIFF
--- a/onig_sys/build.rs
+++ b/onig_sys/build.rs
@@ -94,6 +94,7 @@ fn compile() {
             cc.define("HAVE_UNISTD_H", Some("1"));
             cc.define("HAVE_SYS_TYPES_H", Some("1"));
             cc.define("HAVE_SYS_TIME_H", Some("1"));
+            cc.define("HAVE_ALLOCA_H", Some("1"));
         }
 
         // Can't use size_of::<c_long>(), because it'd refer to build arch, not target arch.


### PR DESCRIPTION
I suppose my gcc must have these warnings as errors cause I was hitting this:
```
   Compiling onig_sys v69.9.1 (/home/luqman/src/oneoff/rust-onig/onig_sys)
warning: onig_sys@69.9.1: In file included from oniguruma/src/regexec.c:36:
warning: onig_sys@69.9.1: oniguruma/src/regexec.c: In function 'match_at':
warning: onig_sys@69.9.1: oniguruma/src/regint.h:271:18: error: implicit declaration of function 'alloca' [-Wimplicit-function-declaration]
warning: onig_sys@69.9.1:   271 | #define xalloca  alloca
warning: onig_sys@69.9.1:       |                  ^~~~~~
warning: onig_sys@69.9.1: oniguruma/src/regexec.c:1350:26: note: in expansion of macro 'xalloca'
warning: onig_sys@69.9.1:  1350 |     alloc_base = (char* )xalloca(sizeof(StkPtrType) * msa->ptr_num\
warning: onig_sys@69.9.1:       |                          ^~~~~~~
warning: onig_sys@69.9.1: oniguruma/src/regexec.c:3057:3: note: in expansion of macro 'STACK_INIT'
warning: onig_sys@69.9.1:  3057 |   STACK_INIT(INIT_MATCH_STACK_SIZE);
warning: onig_sys@69.9.1:       |   ^~~~~~~~~~
error: failed to run custom build command for `onig_sys v69.9.1 (/home/luqman/src/oneoff/rust-onig/onig_sys)
```